### PR TITLE
Lua 5.2 compatibility with fallbacks for Lua 5.1

### DIFF
--- a/common.c
+++ b/common.c
@@ -2,14 +2,6 @@
 #include <assert.h>
 #include "common.h"
 
-// lua 5.1.x and 5.2.x compatable way to mass set functions on an object
-void luv_setfuncs(lua_State *L, const luaL_Reg *l) {
-  for (; l->name != NULL; l++) {
-    lua_pushcfunction(L, l->func);
-    lua_setfield(L, -2, l->name);
-  }
-}
-
 /* Initialize a new lhandle and push the new userdata on the stack. */
 static luv_handle_t* luv_handle_create(lua_State* L, size_t size, int mask) {
 
@@ -20,7 +12,7 @@ static luv_handle_t* luv_handle_create(lua_State* L, size_t size, int mask) {
 
   /* Create a local environment for storing stuff */
   lua_newtable(L);
-  lua_setfenv (L, -2);
+  lua_setuservalue(L, -2);
 
   /* Initialize and return the lhandle */
   lhandle->handle = (uv_handle_t*)malloc(size);
@@ -159,7 +151,7 @@ int luv_get_callback(lua_State* L, int index, const char* name) {
   int top = lua_gettop(L);
 #endif
   /* Get the connection handler */
-  lua_getfenv(L, index);
+  lua_getuservalue(L, index);
   lua_getfield(L, -1, name);
   lua_remove(L, -2);
 

--- a/common.h
+++ b/common.h
@@ -15,6 +15,15 @@
 #include "stdlib.h"
 #include "assert.h"
 
+#if LUA_VERSION_NUM < 502
+/* lua_rawlen: Not entirely correct, but should work anyway */
+#	define lua_rawlen lua_objlen
+/* lua_...uservalue: Something very different, but it should get the job done */
+#	define lua_getuservalue lua_getfenv
+#	define lua_setuservalue lua_setfenv
+#	define luaL_newlib(L,l) (lua_newtable(L), luaL_register(L,NULL,l))
+#	define luaL_setfuncs(L,l,n) (assert(n==0), luaL_register(L,NULL,l))
+#endif
 
 /* Unique type codes for each uv type */
 enum luv_type {
@@ -58,8 +67,6 @@ typedef struct {
   int ref;
 } luv_callback_t;
 
-
-void luv_setfuncs(lua_State *L, const luaL_Reg *l);
 
 lua_State* luv_main_thread;
 

--- a/luv.c
+++ b/luv.c
@@ -4,7 +4,7 @@
 #include "luv_functions.c"
 
 static int luv_newindex(lua_State* L) {
-  lua_getfenv(L, 1);
+  lua_getuservalue(L, 1);
   lua_pushvalue(L, 2);
   lua_pushvalue(L, 3);
   lua_rawset(L, -3);
@@ -30,7 +30,7 @@ static int luv_index(lua_State* L) {
     return 1;
   }
 
-  lua_getfenv(L, 1);
+  lua_getuservalue(L, 1);
   lua_pushvalue(L, 2);
   lua_rawget(L, -2);
   lua_remove(L, -2);
@@ -66,7 +66,6 @@ LUALIB_API int luaopen_luv (lua_State *L) {
   lua_pop(L, 1);
 
   // Module exports
-  lua_newtable (L);
-  luv_setfuncs(L, luv_functions);
+  luaL_newlib(L, luv_functions);
   return 1;
 }

--- a/luv_functions.c
+++ b/luv_functions.c
@@ -226,7 +226,7 @@ static int luv_interface_addresses(lua_State* L) {
     lua_setfield(L, -2, "address");
     lua_pushstring(L, family);
     lua_setfield(L, -2, "family");
-    lua_rawseti(L, -2, lua_objlen (L, -2) + 1);
+    lua_rawseti(L, -2, lua_rawlen (L, -2) + 1);
     lua_pop(L, 1);
   }
   uv_free_interface_addresses(interfaces, count);
@@ -610,7 +610,7 @@ static int luv_write(lua_State* L) {
 
   if (lua_istable(L, 2)) {
     int length, i;
-    length = lua_objlen(L, 2);
+    length = lua_rawlen(L, 2);
     uv_buf_t* bufs = malloc(sizeof(uv_buf_t) * length);
     for (i = 0; i < length; i++) {
       lua_rawgeti(L, 2, i + 1);
@@ -1396,7 +1396,7 @@ static int luv_fs_fchown(lua_State* L) {
 
 /******************************************************************************/
 
-static const luaL_reg luv_functions[] = {
+static const luaL_Reg luv_functions[] = {
   {"new_tcp", new_tcp},
   {"new_timer", new_timer},
   {"new_tty", new_tty},


### PR DESCRIPTION
Use rawlen instead of objlen, uservalues instead of environments.
  This changes behaviour, but achieves the same goal.

Use luaL_newlib instead of a custom luv_setfuncs function,
  but provide a fallback for Lua 5.1 for the former.
