### PR TITLE
Fixed Makefile for OSX (Mavericks)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 uname_S=$(shell uname -s)
 ifeq (Darwin, $(uname_S))
   CFLAGS=-Ilibuv/include -g -I/usr/local/include/luajit-2.0 -DLUV_STACK_CHECK -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Werror -fPIC
-  LIBS=-lm -lluajit-5.1 -framework CoreServices -framework Cocoa
+  LIBS=-lm -lluajit-5.1 -framework CoreServices -framework Cocoa -L/usr/local/lib/
   SHARED_LIB_FLAGS=-bundle -o luv.so luv.o libuv/libuv.a common.o
 else
   CFLAGS=-Ilibuv/include -g -I/usr/local/include/luajit-2.0 -DLUV_STACK_CHECK -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Werror -fPIC


### PR DESCRIPTION
It seems that the latest OS X doesn't include /usr/local/lib in its search path, by default. Since we hard code the include path already, it shouldn't hurt previous OS X versions.
