### PR TITLE
Fixed return type for luv_is_active and luv_has_ref

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -95,7 +95,7 @@ static int luv_has_ref(lua_State* L) {
   uv_handle_t* handle = luv_check_handle(L, 1);
   int ret = uv_has_ref(handle);
   if (ret < 0) return luv_error(L, ret);
-  lua_pushinteger(L, ret);
+  lua_pushboolean(L, ret);
   return 1;
 }
 


### PR DESCRIPTION
This makes more sense on the Lua side and matches the behavior of `luv_is_closing`.
