### PR TITLE
add build flags for solaris

### DIFF
--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -92,6 +92,10 @@ if(WIN32)
     ${LIBUVDIR}/src/win/winsock.h
   )
 else()
+  add_definitions(
+    -D__EXTENSIONS__
+    -D_XOPEN_SOURCE=500
+  )
   include_directories(${LIBUVDIR}/src/unix)
   set(SOURCES ${SOURCES}
     ${LIBUVDIR}/include/uv-unix.h


### PR DESCRIPTION
Can't really see how to check for Solaris using CMake, so the flags are here.

These flags are required to build libuv correctly.