### PR TITLE
luarocks support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,14 @@ cmake_minimum_required(VERSION 2.8)
 project (luv)
 
 include(deps/uv.cmake)
-include(deps/luajit.cmake)
 
-include_directories(deps/luajit/src)
+if (LUV_LUA_INCDIR)
+  include_directories(${LUV_LUA_INCDIR})
+  link_directories(${LUV_LUA_LIBDIR})
+else(LUV_LUA_INCDIR)
+  include(deps/luajit.cmake)
+  include_directories(deps/luajit/src)
+endif(LUV_LUA_INCDIR)
 
 add_library (luv MODULE src/luv.c)
 
@@ -31,3 +36,6 @@ else()
   target_link_libraries(luv uv)
 endif()
 
+if (LUV_INSTALL_PREFIX)
+  install(TARGETS luv DESTINATION "${LUV_INSTALL_PREFIX}/lib")
+endif(LUV_INSTALL_PREFIX)

--- a/luv-1.4.2-1.rockspec
+++ b/luv-1.4.2-1.rockspec
@@ -1,0 +1,33 @@
+package = "luv"
+version = "1.4.2-1"
+source = {
+  url = 'git://github.com/luvit/luv',
+  tag = 'v1.4.2',
+}
+
+description = {
+  summary = "Bare libuv bindings for lua",
+  detailed = [[
+libuv bindings for luajit and lua 5.1/5.2.
+
+This library makes libuv available to lua scripts. It was made for the luvit project but should usable from nearly any lua project.
+  ]],
+  homepage = "https://github.com/luvit/luv",
+  license = "Apache 2.0"
+}
+
+dependencies = {
+  "lua >= 5.1"
+}
+
+-- cmake -Bbuild -H. -DBUILD_SHARED_LIBS=ON
+-- cmake --build build --target install --config Release
+build = {
+  type = 'cmake',
+  variables = {
+    LUV_INSTALL_PREFIX = "$(PREFIX)",
+    LUV_LUA_LIBDIR = "$(LUA_LIBDIR)",
+    LUV_LUA_INCDIR = "$(LUA_INCDIR)",
+    BUILD_SHARED_LIBS="ON",
+  }
+}


### PR DESCRIPTION
Add support for luarocks.

To release:

1. bump version number in rockspec filename and file contents.
1. tag `v1.4.2` in github
2. upload rockspec to  https://rocks.moonscript.org

See [Creating a rock](/keplerproject/luarocks/wiki/Creating-a-rock)