### PR TITLE
fix bug in fs_event_start callback, file fs_event.c

### DIFF
--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -45,17 +45,14 @@ static void luv_fs_event_cb(uv_fs_event_t* handle, const char* filename, int eve
 
   // events
   lua_newtable(L);
-  if (events & UV_FS_EVENT_WATCH_ENTRY) {
+  if (events & UV_RENAME) {
     lua_pushboolean(L, 1);
-    lua_setfield(L, -2, "watch_entry");
+    lua_setfield(L, -2, "rename");
   }
-  if (events & UV_FS_EVENT_STAT) {
+  if (events & UV_CHANGE)
+  {
     lua_pushboolean(L, 1);
-    lua_setfield(L, -2, "stat");
-  }
-  if (events & UV_FS_EVENT_RECURSIVE) {
-    lua_pushboolean(L, 1);
-    lua_setfield(L, -2, "recursive");
+    lua_setfield(L, -2, "change");
   }
 
   luv_call_callback(L, handle->data, LUV_FS_EVENT, 3);

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -49,8 +49,7 @@ static void luv_fs_event_cb(uv_fs_event_t* handle, const char* filename, int eve
     lua_pushboolean(L, 1);
     lua_setfield(L, -2, "rename");
   }
-  if (events & UV_CHANGE)
-  {
+  if (events & UV_CHANGE) {
     lua_pushboolean(L, 1);
     lua_setfield(L, -2, "change");
   }


### PR DESCRIPTION
according to uvbook, http://nikhilm.github.io/uvbook/filesystem.html#file-change-events

```lua
local uv = require('luv')

if #arg==0 then
    print(string.format("Usage: %s <command> <file1> [file2 ...]",arg[0]));
    return
end

for i=1,#arg do
    local fse = uv.new_fs_event()
    assert(uv.fs_event_start(fse,arg[i],{
        --"watch_entry"=true,"stat"=true,
        recursive=true
    },function (err,fname,status)
        if(err) then
            print("Error "..err)
        else
            print(string.format('Change detected in %s',
                uv.fs_event_getpath(fse)))
            for k,v in pairs(status) do
                print(k,v)
            end                
            print('file changed:'..(fname and fname or ''))
        end
    end))
    
end

uv.run('default')
uv.loop_close()

```