### PR TITLE
Add shared linking options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project (luv)
 
-include(deps/uv.cmake)
-
-if (LUV_LUA_INCDIR)
-  include_directories(${LUV_LUA_INCDIR})
-  link_directories(${LUV_LUA_LIBDIR})
-else(LUV_LUA_INCDIR)
-  include(deps/luajit.cmake)
-  include_directories(deps/luajit/src)
-endif(LUV_LUA_INCDIR)
+option(WITH_SHARED_LIBUV "Link to a shared libuv library instead of static linking" OFF)
+option(WITH_SHARED_LUAJIT "Link to a shared LuaJIT library instead of static linking" OFF)
 
 if( NOT EXISTS "deps/libuv/src" )
   execute_process(COMMAND
@@ -22,6 +15,27 @@ if( NOT EXISTS "deps/libuv/src" )
   endif()
 endif()
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+if (WITH_SHARED_LIBUV)
+  find_package(Libuv)
+  if (LIBUV_FOUND)
+    include_directories(${Libuv_INCLUDE_DIRS})
+  endif (LIBUV_FOUND)
+else (WITH_SHARED_LIBUV)
+  include(deps/uv.cmake)
+endif (WITH_SHARED_LIBUV)
+
+if (WITH_SHARED_LUAJIT)
+  find_package(LuaJIT)
+  if (LUAJIT_FOUND)
+    include_directories(${LuaJIT_INCLUDE_DIRS})
+    link_directories(${LUAJIT_LIBRARIES})
+  endif (LUAJIT_FOUND)
+else (WITH_SHARED_LUAJIT)
+  include(deps/luajit.cmake)
+  include_directories(deps/luajit/src)
+endif (WITH_SHARED_LUAJIT)
 
 add_library (luv MODULE src/luv.c)
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ ifdef WITHOUT_AMALG
 	CMAKE_OPTIONS+= -DWITH_AMALG=OFF
 endif
 
+WITH_SHARED_LIBUV ?= OFF
+WITH_SHARED_LUAJIT ?= OFF
+
+CMAKE_OPTIONS += \
+	-DWITH_SHARED_LIBUV=$(WITH_SHARED_LIBUV) \
+	-DWITH_SHARED_LUAJIT=$(WITH_SHARED_LUAJIT)
+
 all: luv
 
 deps/libuv/include:
@@ -38,4 +45,3 @@ publish-luarocks: reset
 	tar -czvf luv-${LUV_TAG}.tar.gz luv-${LUV_TAG}
 	github-release upload --user luvit --repo luv --tag ${LUV_TAG} \
 	  --file luv-${LUV_TAG}.tar.gz --name luv-${LUV_TAG}.tar.gz
-

--- a/cmake/Modules/FindLibuv.cmake
+++ b/cmake/Modules/FindLibuv.cmake
@@ -1,0 +1,11 @@
+# Locate libuv library
+# This module defines
+#  LIBUV_FOUND, if false, do not try to link to libuv
+#  LIBUV_LIBRARIES
+#  LIBUV_INCLUDE_DIR, where to find uv.h
+
+FIND_PATH(LIBUV_INCLUDE_DIR NAMES uv.h)
+FIND_LIBRARY(LIBUV_LIBRARIES NAMES uv libuv)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUV DEFAULT_MSG LIBUV_LIBRARIES LIBUV_INCLUDE_DIR)

--- a/cmake/Modules/FindLuaJIT.cmake
+++ b/cmake/Modules/FindLuaJIT.cmake
@@ -1,0 +1,11 @@
+# Locate LuaJIT library
+# This module defines
+#  LUAJIT_FOUND, if false, do not try to link to Lua JIT
+#  LUAJIT_LIBRARIES
+#  LUAJIT_INCLUDE_DIR, where to find lua.h
+
+FIND_PATH(LUAJIT_INCLUDE_DIR NAMES lua.h)
+FIND_LIBRARY(LUAJIT_LIBRARIES NAMES luajit-5.1)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LUAJIT DEFAULT_MSG LUAJIT_LIBRARIES LUAJIT_INCLUDE_DIR)


### PR DESCRIPTION
Add cmake options `WITH_SHARED_LIBUV` and `WITH_SHARED_LUAJIT` to locate and link against a shared libuv resp. LuaJIT library.

You can use the these options with make:
```WITH_SHARED_LIBUV=ON WITH_SHARED_LUAJIT=ON make```

Based on the wiki *CMake:How To Find Libraries*:
http://www.cmake.org/Wiki/CMake:How_To_Find_Libraries