### PR TITLE
Make luv compatible with Lua5.3

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -352,7 +352,7 @@ static int luv_fs_write(lua_State* L) {
     bufs = luv_prep_bufs(L, 2, &count);
   }
   else if (lua_isstring(L, 2)) {
-    buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+    luv_check_buf(L, 2, &buf);
     count = 1;
   }
   else {

--- a/src/handle.c
+++ b/src/handle.c
@@ -136,6 +136,6 @@ static int luv_fileno(lua_State* L) {
   uv_os_fd_t fd;
   int ret = uv_fileno(handle, &fd);
   if (ret < 0) return luv_error(L, ret);
-  lua_pushinteger(L, (LUA_INTEGER)fd);
+  lua_pushinteger(L, (LUA_INTEGER)(ptrdiff_t)fd);
   return 1;
 }

--- a/src/luv.h
+++ b/src/luv.h
@@ -77,8 +77,6 @@ LUALIB_API int luaopen_luv (lua_State *L);
 #include "lhandle.h"
 #include "lreq.h"
 
-// From luv.c
-
 // From stream.c
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);

--- a/src/luv.h
+++ b/src/luv.h
@@ -29,11 +29,13 @@
 # include <fcntl.h>
 # include <sys/types.h>
 # include <sys/stat.h>
-# define S_ISREG(x)  (((x) & _S_IFMT) == _S_IFREG)
-# define S_ISDIR(x)  (((x) & _S_IFMT) == _S_IFDIR)
-# define S_ISFIFO(x) (((x) & _S_IFMT) == _S_IFIFO)
-# define S_ISCHR(x)  (((x) & _S_IFMT) == _S_IFCHR)
-# define S_ISBLK(x)  0
+# ifndef __MINGW32__
+#   define S_ISREG(x)  (((x) & _S_IFMT) == _S_IFREG)
+#   define S_ISDIR(x)  (((x) & _S_IFMT) == _S_IFDIR)
+#   define S_ISFIFO(x) (((x) & _S_IFMT) == _S_IFIFO)
+#   define S_ISCHR(x)  (((x) & _S_IFMT) == _S_IFCHR)
+#   define S_ISBLK(x)  0
+# endif
 # define S_ISLNK(x)  0
 # define S_ISSOCK(x) 0
 #else
@@ -75,9 +77,13 @@ LUALIB_API int luaopen_luv (lua_State *L);
 #include "lhandle.h"
 #include "lreq.h"
 
+// From luv.c
+
 // From stream.c
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
+static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf);
+static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
 
 // from tcp.c
 static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address, int addrlen);

--- a/src/misc.c
+++ b/src/misc.c
@@ -21,7 +21,7 @@
 #endif
 
 static int luv_guess_handle(lua_State* L) {
-  uv_file file = luaL_checkint(L, 1);
+  uv_file file = luaL_checkinteger(L, 1);
   switch (uv_guess_handle(file)) {
 #define XX(uc, lc) case UV_##uc: lua_pushstring(L, #lc); break;
   UV_HANDLE_TYPE_MAP(XX)
@@ -274,7 +274,7 @@ static int luv_getgid(lua_State* L){
 }
 
 static int luv_setuid(lua_State* L){
-  int uid = luaL_checkint(L, 1);
+  int uid = luaL_checkinteger(L, 1);
   int r = setuid(uid);
   if (-1 == r) {
     luaL_error(L, "Error setting UID");
@@ -283,7 +283,7 @@ static int luv_setuid(lua_State* L){
 }
 
 static int luv_setgid(lua_State* L){
-  int gid = luaL_checkint(L, 1);
+  int gid = luaL_checkinteger(L, 1);
   int r = setgid(gid);
   if (-1 == r) {
     luaL_error(L, "Error setting GID");

--- a/src/stream.c
+++ b/src/stream.c
@@ -16,6 +16,12 @@
  */
 #include "luv.h"
 
+static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf) {
+    size_t len;
+    pbuf->base = (char*)luaL_checklstring(L, idx, &len);
+    pbuf->len = len;
+}
+
 static uv_stream_t* luv_check_stream(lua_State* L, int index) {
   int isStream;
   uv_stream_t* handle;
@@ -141,7 +147,7 @@ static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count) {
   bufs = malloc(sizeof(uv_buf_t) * *count);
   for (i = 0; i < *count; ++i) {
     lua_rawgeti(L, index, i + 1);
-    bufs[i].base = (char*) luaL_checklstring(L, -1, &(bufs[i].len));
+    luv_check_buf(L, -1, &bufs[i]);
     lua_pop(L, 1);
   }
   return bufs;
@@ -162,7 +168,7 @@ static int luv_write(lua_State* L) {
   }
   else if (lua_isstring(L, 2)) {
     uv_buf_t buf;
-    buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+    luv_check_buf(L, 2, &buf);
     ret = uv_write(req, handle, &buf, 1, luv_write_cb);
   }
   else {
@@ -194,7 +200,7 @@ static int luv_write2(lua_State* L) {
   }
   else if (lua_isstring(L, 2)) {
     uv_buf_t buf;
-    buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+    luv_check_buf(L, 2, &buf);
     ret = uv_write2(req, handle, &buf, 1, send_handle, luv_write_cb);
   }
   else {
@@ -220,7 +226,7 @@ static int luv_try_write(lua_State* L) {
   }
   else if (lua_isstring(L, 2)) {
     uv_buf_t buf;
-    buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+    luv_check_buf(L, 2, &buf);
     ret = uv_try_write(handle, &buf, 1);
   }
   else {

--- a/src/thread.c
+++ b/src/thread.c
@@ -129,7 +129,7 @@ static const char* luv_thread_dumped(lua_State* L, int idx, size_t *l) {
   } else {
     const char* buff;
     luaL_checktype(L, idx, LUA_TFUNCTION);
-    lua_getfield(L, LUA_GLOBALSINDEX, "string");
+    lua_getglobal(L, "string");
     lua_getfield(L, -1, "dump");
     lua_remove(L, -2);
     lua_pushvalue(L, idx);

--- a/src/udp.c
+++ b/src/udp.c
@@ -160,7 +160,7 @@ static int luv_udp_send(lua_State* L) {
   int ret, port, ref;
   const char* host;
   struct sockaddr_storage addr;
-  buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+  luv_check_buf(L, 2, &buf);
   host = luaL_checkstring(L, 3);
   port = luaL_checkinteger(L, 4);
   if (uv_ip4_addr(host, port, (struct sockaddr_in*)&addr) &&
@@ -185,7 +185,7 @@ static int luv_udp_try_send(lua_State* L) {
   int ret, port;
   const char* host;
   struct sockaddr_storage addr;
-  buf.base = (char*) luaL_checklstring(L, 2, &buf.len);
+  luv_check_buf(L, 2, &buf);
   host = luaL_checkstring(L, 3);
   port = luaL_checkinteger(L, 4);
   if (uv_ip4_addr(host, port, (struct sockaddr_in*)&addr) &&


### PR DESCRIPTION
- add function luv_check_buf() to avoid warnings in MinGW (convert DWORD* to size_t*)
- avoid MinGW warnings that defined macros (S_IS* macros)
- change luaL_checkint to luaL_checkinteger
- use lua_getglobal() instead LUA_GLOBALSINDEX

some improves againest #147 