### PR TITLE
Userenv.lib is missing in the uv.cmake

### DIFF
--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -199,6 +199,7 @@ if(WIN32)
     psapi.lib
     iphlpapi.lib
     advapi32.lib
+    Userenv.lib
   )
 endif()
 


### PR DESCRIPTION
  uv.lib(util.obj) : error LNK2019: 无法解析的外部符号 __imp__GetUserProfileDire
ctoryW@12，该符号在函数 _uv_os_homedir 中被引用 [E:\developing\c\luvi\build\luvi.vcxproj
]