### PR TITLE
don't free the buff if it is null.

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -100,7 +100,10 @@ static void luv_read_cb(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf)
     nargs = 2;
   }
 
-  free(buf->base);
+  if (buf->base != 0 && buf->len != 0) {
+    free(buf->base);
+  }
+
   if (nread == 0) return;
 
   if (nread == UV_EOF) {


### PR DESCRIPTION
http://docs.libuv.org/en/latest/stream.html#c.uv_read_start says that but.base can be set to 0 in certain cases. This accounts for that, and only frees the bf.base if it has been set to a value.