### PR TITLE
process: cleanup the lua handle in the close callback

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -219,6 +219,9 @@ static int luv_spawn(lua_State* L) {
 
   luv_clean_options(&options);
   if (ret < 0) {
+    /* The async callback is required here because luajit GC may reclaim the
+     * luv handle before libuv is done closing it down.
+     */
     uv_close((uv_handle_t*)handle, luv_spawn_close_cb);
     return luv_error(L, ret);
   }


### PR DESCRIPTION
* The close callback happens after the endgames, so it is safe to
  destroy