### PR TITLE
Set correct installation path for luv module on non-WIN32 targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,6 @@ endif ()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib"
-	CACHE PATH "Installation directory for libraries")
-set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include/luv"
-	CACHE PATH "Installation directory for headers")
-
 if (WITH_SHARED_LIBUV)
   find_package(Libuv)
   if (LIBUV_FOUND)
@@ -121,6 +116,19 @@ elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 else()
   target_link_libraries(luv uv)
 endif()
+
+if (BUILD_MODULE)
+  if (WIN32)
+    set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+  else (WIN32)
+    set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib/lua/${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}")
+  endif (WIN32)
+else (BUILD_MODULE)
+  set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+    CACHE PATH "Installation directory for libraries")
+  set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include/luv"
+    CACHE PATH "Installation directory for headers")
+endif (BUILD_MODULE)
 
 if (CMAKE_INSTALL_PREFIX)
   install(TARGETS luv

--- a/cmake/Modules/FindLuaJIT.cmake
+++ b/cmake/Modules/FindLuaJIT.cmake
@@ -1,11 +1,55 @@
+#=============================================================================
+# Copyright 2007-2009 Kitware, Inc.
+# Copyright 2013 Rolf Eike Beer <eike@sf-mail.de>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# We use code from the CMake project to detect the Lua version.
+
 # Locate LuaJIT library
 # This module defines
 #  LUAJIT_FOUND, if false, do not try to link to Lua JIT
 #  LUAJIT_LIBRARIES
 #  LUAJIT_INCLUDE_DIR, where to find lua.h
+#
+# Additionally it defines the Lua API/ABI version:
+#  LUA_VERSION_STRING - the version of Lua found
+#  LUA_VERSION_MAJOR  - the major version of Lua
+#  LUA_VERSION_MINOR  - the minor version of Lua
+#  LUA_VERSION_PATCH  - the patch version of Lua
 
 FIND_PATH(LUAJIT_INCLUDE_DIR NAMES lua.h PATH_SUFFIXES luajit-2.0)
 FIND_LIBRARY(LUAJIT_LIBRARIES NAMES luajit-5.1)
+
+if (LUAJIT_INCLUDE_DIR AND EXISTS "${LUAJIT_INCLUDE_DIR}/lua.h")
+    # At least 5.[012] have different ways to express the version
+    # so all of them need to be tested. Lua 5.2 defines LUA_VERSION
+    # and LUA_RELEASE as joined by the C preprocessor, so avoid those.
+    file(STRINGS "${LUAJIT_INCLUDE_DIR}/lua.h" lua_version_strings
+         REGEX "^#define[ \t]+LUA_(RELEASE[ \t]+\"Lua [0-9]|VERSION([ \t]+\"Lua [0-9]|_[MR])).*")
+
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MAJOR ";${lua_version_strings};")
+    if (LUA_VERSION_MAJOR MATCHES "^[0-9]+$")
+        string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MINOR ";${lua_version_strings};")
+        string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_PATCH ";${lua_version_strings};")
+        set(LUA_VERSION_STRING "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
+    else ()
+        string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+        if (NOT LUA_VERSION_STRING MATCHES "^[0-9.]+$")
+            string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+        endif ()
+        string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" LUA_VERSION_MAJOR "${LUA_VERSION_STRING}")
+        string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" LUA_VERSION_MINOR "${LUA_VERSION_STRING}")
+        string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" LUA_VERSION_PATCH "${LUA_VERSION_STRING}")
+    endif ()
+
+    unset(lua_version_strings)
+endif()
 
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LUAJIT DEFAULT_MSG LUAJIT_LIBRARIES LUAJIT_INCLUDE_DIR)


### PR DESCRIPTION
The search path for loading binary modules with the require function is
`LUA_ROOT "lib/lua/" LUA_VERSION_MAJOR "." LUA_VERSION_MINOR` on non-WIN32
targets.

Let us use this default path for installing the luv module. This allows the user to use

```lua
local uv = require('luv')
```

from every directory path.