### PR TITLE
Add a "mac" field to the luv_interface_addresses().

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -192,6 +192,9 @@ static int luv_interface_addresses(lua_State* L) {
     lua_pushboolean(L, interfaces[i].is_internal);
     lua_setfield(L, -2, "internal");
 
+    lua_pushlstring(L, interfaces[i].phys_addr, sizeof(interfaces[i].phys_addr));
+    lua_setfield(L, -2, "mac");
+
     if (interfaces[i].address.address4.sin_family == AF_INET) {
       uv_ip4_name(&interfaces[i].address.address4,ip, sizeof(ip));
     } else if (interfaces[i].address.address4.sin_family == AF_INET6) {


### PR DESCRIPTION
Note that this is the "raw" mac address (not converted into <HEX><HEX>:... notation). The purpose of this change was to allow me to write an implementation of UUID generation (version 4): http://www.ietf.org/rfc/rfc4122.txt

...and for that purpose, having the "raw" mac address is more convenient.

However, if the project maintainer feels it would be better to have the "pretty" HEX notation, I can add the conversion code. Please just let me know.

Thanks,
-Brian