### PR TITLE
change luajit submodule url to https://github.com/LuaJIT/LuaJIT.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/libuv/libuv.git
 [submodule "luajit"]
 	path = deps/luajit
-	url = http://luajit.org/git/luajit-2.0.git
+	url = https://github.com/LuaJIT/LuaJIT.git
 [submodule "lua"]
 	path = deps/lua
 	url = https://github.com/lua/lua


### PR DESCRIPTION
fix travis fail, because luajit can't access.