### PR TITLE
Change fs_scandir_next() to return two values instead of a table

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -416,24 +416,21 @@ static int luv_fs_scandir_next(lua_State* L) {
     return 0;
   }
   if (ret < 0) return luv_error(L, ret);
-  lua_createtable(L, 0, 2);
   lua_pushstring(L, ent.name);
-  lua_setfield(L, -2, "name");
+  if (ent.type == UV_DIRENT_UNKNOWN) return 1;
   switch (ent.type) {
-    case UV_DIRENT_UNKNOWN: type = NULL; break;
-    case UV_DIRENT_FILE: type = "file"; break;
-    case UV_DIRENT_DIR: type = "directory"; break;
-    case UV_DIRENT_LINK: type = "link"; break;
-    case UV_DIRENT_FIFO: type = "fifo"; break;
+    case UV_DIRENT_FILE:   type = "file"; break;
+    case UV_DIRENT_DIR:    type = "directory"; break;
+    case UV_DIRENT_LINK:   type = "link"; break;
+    case UV_DIRENT_FIFO:   type = "fifo"; break;
     case UV_DIRENT_SOCKET: type = "socket"; break;
-    case UV_DIRENT_CHAR: type = "char"; break;
-    case UV_DIRENT_BLOCK: type = "block"; break;
+    case UV_DIRENT_CHAR:   type = "char"; break;
+    case UV_DIRENT_BLOCK:  type = "block"; break;
+    default:
+      assert(0);
   }
-  if (type) {
-    lua_pushstring(L, type);
-    lua_setfield(L, -2, "type");
-  }
-  return 1;
+  lua_pushstring(L, type);
+  return 2;
 }
 
 static int luv_fs_stat(lua_State* L) {

--- a/src/fs.c
+++ b/src/fs.c
@@ -417,17 +417,16 @@ static int luv_fs_scandir_next(lua_State* L) {
   }
   if (ret < 0) return luv_error(L, ret);
   lua_pushstring(L, ent.name);
-  if (ent.type == UV_DIRENT_UNKNOWN) return 1;
   switch (ent.type) {
-    case UV_DIRENT_FILE:   type = "file"; break;
-    case UV_DIRENT_DIR:    type = "directory"; break;
-    case UV_DIRENT_LINK:   type = "link"; break;
-    case UV_DIRENT_FIFO:   type = "fifo"; break;
-    case UV_DIRENT_SOCKET: type = "socket"; break;
-    case UV_DIRENT_CHAR:   type = "char"; break;
-    case UV_DIRENT_BLOCK:  type = "block"; break;
-    default:
-      assert(0);
+    case UV_DIRENT_UNKNOWN: return 1;
+    case UV_DIRENT_FILE:    type = "file"; break;
+    case UV_DIRENT_DIR:     type = "directory"; break;
+    case UV_DIRENT_LINK:    type = "link"; break;
+    case UV_DIRENT_FIFO:    type = "fifo"; break;
+    case UV_DIRENT_SOCKET:  type = "socket"; break;
+    case UV_DIRENT_CHAR:    type = "char"; break;
+    case UV_DIRENT_BLOCK:   type = "block"; break;
+    default: assert(0);
   }
   lua_pushstring(L, type);
   return 2;

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -18,17 +18,16 @@ _G.isWindows = isWindows
 
 local req = uv.fs_scandir("tests")
 
-repeat
-  local ent = uv.fs_scandir_next(req)
-
-  if not ent then
-    -- run the tests!
-    tap(true)
-  end
-  local match = string.match(ent.name, "^test%-(.*).lua$")
+while true do
+  local name = uv.fs_scandir_next(req)
+  if not name then break end
+  local match = string.match(name, "^test%-(.*).lua$")
   if match then
     local path = "tests/test-" .. match
     tap(match)
     require(path)
   end
-until not ent
+end
+
+-- run the tests!
+tap(true)

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -71,13 +71,13 @@ return require('lib/tap')(function (test)
     local function iter()
       return uv.fs_scandir_next(req)
     end
-    for entry in iter do
-      p(entry)
-      assert(entry.name)
-      -- assert(entry.type) -- TODO: find out why this fails on travis containers.
+    for name, ftype in iter do
+      p{name=name, ftype=ftype}
+      assert(name)
+      -- ftype is not available in all filesystems; e.g. it's provided
+      -- for HFS+ (OSX), but not for ext4 (Linux).
     end
   end)
-
 
   test("fs.realpath", function (print, p, expect, uv)
     p(assert(uv.fs_realpath('.')))

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -74,8 +74,8 @@ return require('lib/tap')(function (test)
     for name, ftype in iter do
       p{name=name, ftype=ftype}
       assert(name)
-      -- ftype is not available in all filesystems; e.g. it's provided
-      -- for HFS+ (OSX), but not for ext4 (Linux).
+      -- ftype is not available in all filesystems; for example it's
+      -- provided for HFS+ (OSX), NTFS (Windows) but not for ext4 (Linux).
     end
   end)
 

--- a/tests/test-timer.lua
+++ b/tests/test-timer.lua
@@ -32,18 +32,18 @@ return require('lib/tap')(function (test)
   end)
 
   -- Test two concurrent timers
-  -- There is a small race condition, but there are 50ms of wiggle room.
-  -- 250ms is halfway between 2x100ms and 3x100ms
+  -- There is a small race condition, but there are 100ms of wiggle room.
+  -- 400ms is halfway between 100+200ms and 100+400ms
   test("timeout with interval", function (print, p, expect, uv)
     local a = uv.new_timer()
     local b = uv.new_timer()
-    uv.timer_start(a, 250, 0, expect(function ()
+    uv.timer_start(a, 400, 0, expect(function ()
       p("timeout", a)
       uv.timer_stop(b)
       uv.close(a)
       uv.close(b)
     end))
-    uv.timer_start(b, 100, 100, expect(function ()
+    uv.timer_start(b, 100, 200, expect(function ()
       p("interval", b)
     end, 2))
   end)


### PR DESCRIPTION
Changes:
- Closes #201 (Change `fs_scandir_next()` to return two values instead of a table)
- Increase interval tolerance in test "timer - timeout with interval" in order to avoid random fails on AppVeyor and slow CI servers. Increased from 50ms to 100ms.