### PR TITLE
Fix warnings

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -308,7 +308,7 @@ static int luv_constants(lua_State* L) {
   return 1;
 }
 
-static const int luv_af_string_to_num(const char* string) {
+static int luv_af_string_to_num(const char* string) {
   if (!string) return AF_UNSPEC;
 #ifdef AF_UNIX
   if (strcmp(string, "unix") == 0) return AF_UNIX;
@@ -380,7 +380,7 @@ static const char* luv_af_num_to_string(const int num) {
 }
 
 
-static const int luv_ai_string_to_num(const char* string) {
+static int luv_ai_string_to_num(const char* string) {
   if (!string) return 0;
 #ifdef AI_ADDRCONFIG
   if (strcmp(string, "addrconfig") == 0) return AI_ADDRCONFIG;
@@ -427,7 +427,7 @@ static const char* luv_ai_num_to_string(const int num) {
   return NULL;
 }
 
-static const int luv_sock_string_to_num(const char* string) {
+static int luv_sock_string_to_num(const char* string) {
   if (!string) return 0;
 #ifdef SOCK_STREAM
   if (strcmp(string, "stream") == 0) return SOCK_STREAM;
@@ -468,7 +468,7 @@ static const char* luv_sock_num_to_string(const int num) {
   return NULL;
 }
 
-static const int luv_sig_string_to_num(const char* string) {
+static int luv_sig_string_to_num(const char* string) {
   if (!string) return 0;
 #ifdef SIGHUP
   if (strcmp(string, "sighup") == 0) return SIGHUP;

--- a/src/constants.c
+++ b/src/constants.c
@@ -380,53 +380,6 @@ static const char* luv_af_num_to_string(const int num) {
 }
 
 
-static int luv_ai_string_to_num(const char* string) {
-  if (!string) return 0;
-#ifdef AI_ADDRCONFIG
-  if (strcmp(string, "addrconfig") == 0) return AI_ADDRCONFIG;
-#endif
-#ifdef AI_V4MAPPED
-  if (strcmp(string, "v4mapped") == 0) return AI_V4MAPPED;
-#endif
-#ifdef AI_ALL
-  if (strcmp(string, "all") == 0) return AI_ALL;
-#endif
-#ifdef AI_NUMERICHOST
-  if (strcmp(string, "numerichost") == 0) return AI_NUMERICHOST;
-#endif
-#ifdef AI_PASSIVE
-  if (strcmp(string, "passive") == 0) return AI_PASSIVE;
-#endif
-#ifdef AI_NUMERICSERV
-  if (strcmp(string, "numericserv") == 0) return AI_NUMERICSERV;
-#endif
-  return 0;
-}
-
-static const char* luv_ai_num_to_string(const int num) {
-  switch (num) {
-#ifdef AI_ADDRCONFIG
-  case AI_ADDRCONFIG: return "addrconfig";
-#endif
-#ifdef AI_V4MAPPED
-  case AI_V4MAPPED: return "v4mapped";
-#endif
-#ifdef AI_ALL
-  case AI_ALL: return "all";
-#endif
-#ifdef AI_NUMERICHOST
-  case AI_NUMERICHOST: return "numerichost";
-#endif
-#ifdef AI_PASSIVE
-  case AI_PASSIVE: return "passive";
-#endif
-#ifdef AI_NUMERICSERV
-  case AI_NUMERICSERV: return "numericserv";
-#endif
-  }
-  return NULL;
-}
-
 static int luv_sock_string_to_num(const char* string) {
   if (!string) return 0;
 #ifdef SOCK_STREAM

--- a/src/fs.c
+++ b/src/fs.c
@@ -428,6 +428,7 @@ static int luv_fs_scandir_next(lua_State* L) {
     case UV_DIRENT_SOCKET: type = "socket"; break;
     case UV_DIRENT_CHAR: type = "char"; break;
     case UV_DIRENT_BLOCK: type = "block"; break;
+    default: type = NULL;
   }
   if (type) {
     lua_pushstring(L, type);

--- a/src/luv.c
+++ b/src/luv.c
@@ -461,6 +461,7 @@ LUALIB_API uv_loop_t* luv_loop(lua_State* L) {
 
 static void walk_cb(uv_handle_t *handle, void *arg)
 {
+  (void)arg;
   if (!uv_is_closing(handle)) {
     uv_close(handle, luv_close_cb);
   }

--- a/src/luv.h
+++ b/src/luv.h
@@ -92,13 +92,13 @@ static void luv_connect_cb(uv_connect_t* req, int status);
 static void luv_push_stats_table(lua_State* L, const uv_stat_t* s);
 
 // from constants.c
-static const int luv_af_string_to_num(const char* string);
+static int luv_af_string_to_num(const char* string);
 static const char* luv_af_num_to_string(const int num);
-static const int luv_ai_string_to_num(const char* string);
+static int luv_ai_string_to_num(const char* string);
 static const char* luv_ai_num_to_string(const int num);
-static const int luv_sock_string_to_num(const char* string);
+static int luv_sock_string_to_num(const char* string);
 static const char* luv_sock_num_to_string(const int num);
-static const int luv_sig_string_to_num(const char* string);
+static int luv_sig_string_to_num(const char* string);
 static const char* luv_sig_num_to_string(const int num);
 
 typedef lua_State* (*luv_acquire_vm)();

--- a/src/luv.h
+++ b/src/luv.h
@@ -94,8 +94,6 @@ static void luv_push_stats_table(lua_State* L, const uv_stat_t* s);
 // from constants.c
 static int luv_af_string_to_num(const char* string);
 static const char* luv_af_num_to_string(const int num);
-static int luv_ai_string_to_num(const char* string);
-static const char* luv_ai_num_to_string(const int num);
 static int luv_sock_string_to_num(const char* string);
 static const char* luv_sock_num_to_string(const int num);
 static int luv_sig_string_to_num(const char* string);

--- a/src/poll.c
+++ b/src/poll.c
@@ -82,6 +82,7 @@ static int luv_poll_start(lua_State* L) {
     case 0: events = UV_READABLE; break;
     case 1: events = UV_WRITABLE; break;
     case 2: events = UV_READABLE | UV_WRITABLE; break;
+    default: events = 0; /* unreachable */
   }
   luv_check_callback(L, handle->data, LUV_POLL, 3);
   ret = uv_poll_start(handle, events, luv_poll_cb);

--- a/src/process.c
+++ b/src/process.c
@@ -17,6 +17,7 @@
 #include "luv.h"
 
 static int luv_disable_stdio_inheritance(lua_State* L) {
+  (void)L;
   uv_disable_stdio_inheritance();
   return 0;
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -85,6 +85,7 @@ static int luv_accept(lua_State* L) {
 }
 
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
+  (void)handle;
   buf->base = malloc(suggested_size);
   assert(buf->base);
   buf->len = suggested_size;

--- a/src/work.c
+++ b/src/work.c
@@ -114,6 +114,7 @@ static void luv_after_work_cb(uv_work_t* req, int status) {
   luv_work_ctx_t* ctx = work->ctx;
   lua_State*L = ctx->L;
   int i;
+  (void)status;
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->after_work_cb);
   i = luv_thread_arg_push(L, &work->arg);
   if (lua_pcall(L, i, 0, 0))

--- a/src/work.c
+++ b/src/work.c
@@ -62,7 +62,6 @@ static int luv_work_ctx_tostring(lua_State* L)
 
 static void luv_work_cb(uv_work_t* req)
 {
-  uv_thread_t tid = uv_thread_self();
   luv_work_t* work = req->data;
   luv_work_ctx_t* ctx = work->ctx;
   lua_State *L = uv_key_get(&L_key);


### PR DESCRIPTION
This PR fixes nearly all of the warnings emitted by gcc with -Wall -Wextra.
Only warnings from the dependencies (which are unused parameter warnings) remain.

Fixes #197