### PR TITLE
Fix incorrect behaviour on Windows related to stdio pipes being read-write

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -111,7 +111,8 @@ static int luv_spawn(lua_State* L) {
         uv_stream_t* stream = luv_check_stream(L, -1);
         int err = uv_fileno((uv_handle_t*)stream, &fd);
         if (err == UV_EINVAL || err == UV_EBADF) {
-          options.stdio[i].flags = UV_CREATE_PIPE | UV_READABLE_PIPE | UV_WRITABLE_PIPE;
+          options.stdio[i].flags =
+              UV_CREATE_PIPE | (i == 0 ? UV_READABLE_PIPE : UV_WRITABLE_PIPE);
         }
         else {
           options.stdio[i].flags = UV_INHERIT_STREAM;
@@ -257,4 +258,3 @@ static int luv_kill(lua_State* L) {
   lua_pushinteger(L, ret);
   return 1;
 }
-

--- a/src/process.c
+++ b/src/process.c
@@ -111,8 +111,14 @@ static int luv_spawn(lua_State* L) {
         uv_stream_t* stream = luv_check_stream(L, -1);
         int err = uv_fileno((uv_handle_t*)stream, &fd);
         if (err == UV_EINVAL || err == UV_EBADF) {
-          options.stdio[i].flags =
-              UV_CREATE_PIPE | (i == 0 ? UV_READABLE_PIPE : UV_WRITABLE_PIPE);
+          // stdin (fd 0) is read-only, stdout and stderr (fds 1 & 2) are
+          // write-only, and all fds > 2 are read-write
+          int flags = UV_CREATE_PIPE;
+          if (i == 0 || i > 2)
+            flags |= UV_READABLE_PIPE;
+          if (i != 0)
+            flags |= UV_WRITABLE_PIPE;
+          options.stdio[i].flags = flags;
         }
         else {
           options.stdio[i].flags = UV_INHERIT_STREAM;


### PR DESCRIPTION
Unfortunately if we always always create the stdio pipes as R+W (instead of only R for stdin, and only W for stdout and stderr) child processes on windows start to behave incorrectly. For example, if you spawn the 'cat' program, write to it and then shutdown its stdin, the correct behaviour is for the child to receive EOF and exit. But if stdin is RW the child never exits on Windows, and you have to kill the process to force it to exit. Changing the stdin pipe to only `UV_CREATE_PIPE|UV_READABLE_PIPE` fixes the problem.

The current solution assumes only the standard stdio fd's (0-2) are used. A more flexible solution may be in order, but would require an API change.