### PR TITLE
bump to luajit 2.1

### DIFF
--- a/deps/luajit.cmake
+++ b/deps/luajit.cmake
@@ -224,6 +224,9 @@ SET(SRC_LJCORE
   ${LUAJIT_DIR}/src/lj_gc.c
   ${LUAJIT_DIR}/src/lj_err.c
   ${LUAJIT_DIR}/src/lj_char.c
+  ${LUAJIT_DIR}/src/lj_buf.c
+  ${LUAJIT_DIR}/src/lj_profile.c
+  ${LUAJIT_DIR}/src/lj_strfmt.c
   ${LUAJIT_DIR}/src/lj_bc.c
   ${LUAJIT_DIR}/src/lj_obj.c
   ${LUAJIT_DIR}/src/lj_str.c

--- a/tests/test-conversions.lua
+++ b/tests/test-conversions.lua
@@ -1,0 +1,6 @@
+return require('lib/tap')(function (test)
+  test("basic 64bit conversions", function (print, p, expect, uv)
+    assert(string.format("%x", 29913653248) == "6f6fe2000")
+    assert(string.format("%x", 32207650816) == "77fb9c000")
+  end)
+end)


### PR DESCRIPTION
* 64bit integer conversions do not work on Windows with 2.0.4

`29913653248` is converted to `0xf6fe2000`. Note: The low 32bits are correct, but the high 32 bits is missing. The correct answer is: `0x6f6fe2000`.

`32207650816` is converted to `0x7fb9c000`. The correct answer is `0x77fb9c000`.

Update: Luajit 2.1 does fix the issue on Windows.