### PR TITLE
Use luarocks native build on rockspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,13 @@ script:
   - source .ci/setenv_lua.sh
   - luarocks make
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
+  - luarocks remove luv
+  # Test the alternate rockspec
+  - mkdir build/lib
+  - cp build/libuv.a build/lib
+  - cp -a deps/libuv/include build
+  - luarocks make rockspecs/$(ls rockspecs) LIBUV_DIR=build
+  - test $PWD = `lua -e "print(require'luv'.cwd())"`
 
 notifications:
   email: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,13 @@ build_script:
   - luarocks make
   - ps: if("$(Get-Location)" -eq $(lua -e "print(require'luv'.cwd())")) { "LuaRocks test OK" } else { "LuaRocks test failed"; exit 1 }
   - luarocks remove luv
+    # Test the alternate rockspec
+  - mkdir build\lib
+  - cp build\Release\uv.lib build\lib
+  - cp -a deps\libuv\include build
+  - ps: luarocks make rockspecs\$(ls rockspecs) LIBUV_DIR=build CFLAGS="/nologo /MT /O2"
+  - ps: if("$(Get-Location)" -eq $(lua -e "print(require'luv'.cwd())")) { "LuaRocks test OK" } else { "LuaRocks test failed"; exit 1 }
+  - luarocks remove luv
 
 artifacts:
   - path: luv.dll

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+version=$1
+if [ -z "$version" ]; then
+  echo "must specify a version" >&2
+  exit 1
+fi
+
+script="/^version/s@\"[^\"]\\+\"@\"${version}\"@"
+sed -e "${script}" -i luv-*.rockspec
+sed -e "${script}" -i rockspecs/luv-*.rockspec
+git mv luv-*.rockspec luv-${version}.rockspec
+git mv rockspecs/luv-*.rockspec rockspecs/luv-${version}.rockspec
+git add luv-${version}.rockspec rockspecs/luv-${version}.rockspec

--- a/luv-1.8.0-4.rockspec
+++ b/luv-1.8.0-4.rockspec
@@ -1,7 +1,7 @@
 package = "luv"
 version = "1.8.0-4"
 source = {
-  url = 'https://github.com/luvit/luv/releases/download/1.8.0-4/luv-1.8.0-4.tar.gz',
+  url = 'https://github.com/luvit/luv/releases/download/'..version..'/luv-'..version..'.tar.gz'
 }
 
 description = {

--- a/rockspecs/luv-1.8.0-4.rockspec
+++ b/rockspecs/luv-1.8.0-4.rockspec
@@ -1,0 +1,79 @@
+-- Alternate rockspec that uses luarocks builtin builder
+package = "luv"
+version = "1.8.0-4"
+source = {
+  url = 'https://github.com/luvit/luv/releases/download/'..version..'/luv-'..version..'.tar.gz'
+}
+
+description = {
+  summary = "Bare libuv bindings for lua",
+  detailed = [[
+libuv bindings for luajit and lua 5.1/5.2/5.3.
+
+This library makes libuv available to lua scripts. It was made for the luvit
+project but should usable from nearly any lua project.
+  ]],
+  homepage = "https://github.com/luvit/luv",
+  license = "Apache 2.0"
+}
+
+dependencies = {
+  "lua >= 5.1"
+}
+
+external_dependencies = {
+  LIBUV = {
+    header = 'uv.h'
+  }
+}
+
+local function make_modules()
+  return {
+    ['luv'] = {
+      sources = {'src/luv.c'},
+      libraries = {'uv'},
+      incdirs = {"$(LIBUV_INCDIR)"},
+      libdirs = {"$(LIBUV_LIBDIR)"}
+    }
+  }
+end
+
+local function make_plat(plat)
+  local modules = make_modules()
+  local libs = modules['luv'].libraries
+
+  if plat == 'windows' then
+    libs[#libs + 1] = 'psapi'
+    libs[#libs + 1] = 'iphlpapi'
+    libs[#libs + 1] = 'userenv'
+    libs[#libs + 1] = 'ws2_32'
+    libs[#libs + 1] = 'advapi32'
+  else
+    libs[#libs + 1] = 'pthread'
+  end
+
+  if plat == 'freebsd' then
+    libs[#libs + 1] = 'kvm'
+  end
+
+  if plat == 'linux' then
+    libs[#libs + 1] = 'rt'
+    libs[#libs + 1] = 'dl'
+  end
+
+  return { modules = modules }
+end
+
+build = {
+  type = 'builtin',
+  -- default (platform-agnostic) configuration
+  modules = make_modules(),
+
+  -- per-platform overrides
+  -- https://github.com/keplerproject/luarocks/wiki/Platform-agnostic-external-dependencies
+  platforms = {
+    linux = make_plat('linux'),
+    freebsd = make_plat('freebsd'),
+    windows = make_plat('windows')
+  }
+}


### PR DESCRIPTION
This should make luv more compatible with luarocks echosystem:

- Doesn't depend on cmake(which may not be available). luv is very simple to
  compile, and cmake is used more to setup dependencies, but this is already
  taken care of by luarocks.
- Allows the user to specify custom libuv prefixes with LIBUV_DIR(which is the
  idiomatic way of specifying dependencies location in luarocks)
- Respects CC

Close #223