### PR TITLE
uv.cmake: fix case of "userenv" library

### DIFF
--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -200,7 +200,7 @@ if(WIN32)
     psapi.lib
     iphlpapi.lib
     advapi32.lib
-    Userenv.lib
+    userenv.lib
   )
 endif()
 


### PR DESCRIPTION
This fixes linking errors when cross-compiling luv using MinGW.
A Unix filesystem backing userenv.lib file is case-sensitive.