### PR TITLE
Build in OpenBSD

### DIFF
--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -195,6 +195,12 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
   )
 endif()
 
+if("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+  target_link_libraries(uv Threads::Threads)
+endif()
+
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   target_link_libraries(uv
     pthread

--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -138,6 +138,14 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
   )
 endif()
 
+## OpenBSD
+if("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
+  set(SOURCES ${SOURCES}
+    ${LIBUVDIR}/src/unix/kqueue.c
+    ${LIBUVDIR}/src/unix/openbsd.c
+  )
+endif()
+
 ## Linux
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   add_definitions(

--- a/src/dns.c
+++ b/src/dns.c
@@ -150,13 +150,17 @@ static int luv_getaddrinfo(lua_State* L) {
     if (lua_toboolean(L, -1)) hints->ai_flags |=  AI_ADDRCONFIG;
     lua_pop(L, 1);
 
+#ifdef AI_V4MAPPED
     lua_getfield(L, 3, "v4mapped");
     if (lua_toboolean(L, -1)) hints->ai_flags |=  AI_V4MAPPED;
     lua_pop(L, 1);
+#endif
 
+#ifdef AI_ALL
     lua_getfield(L, 3, "all");
     if (lua_toboolean(L, -1)) hints->ai_flags |=  AI_ALL;
     lua_pop(L, 1);
+#endif
 
     lua_getfield(L, 3, "numerichost");
     if (lua_toboolean(L, -1)) hints->ai_flags |=  AI_NUMERICHOST;


### PR DESCRIPTION
For #229, fix the uv.cmake recipe for OpenBSD and avoid using AI_ flags in systems where they are not available.

When loading the luv module you may still encounter an error. The workaround is to set LD_PRELOAD=/usr/lib/libpthread.so before calling the lua interpreter. I am still investigating this issue but AFAIK this also happens with other lua modules e.g.

    http://openports.se/devel/lua-lgi