### PR TITLE
Fix #204: sparse stdio in process:spawn()

### DIFF
--- a/src/luv.h
+++ b/src/luv.h
@@ -59,6 +59,9 @@
 # define luaL_setfuncs(L,l,n) (assert(n==0), luaL_register(L,NULL,l))
 # define lua_resume(L,F,n) lua_resume(L,n)
 # define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)
+# define lua_absindex(L, i)                              \
+    ((i) > 0 || (i) <= LUA_REGISTRYINDEX ?              \
+     (i) : lua_gettop(L) + (i) + 1)
 #endif
 
 /* There is a 1-1 relation between a lua_State and a uv_loop_t


### PR DESCRIPTION
Define and use sparse_rawlen() for the stdio options passed into
process:spawn(). This fixes https://github.com/luvit/luv/issues/204
