### PR TITLE
Make type checking for handles more robust. (#234)

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -77,7 +77,6 @@ static void luv_close_cb(uv_handle_t* handle) {
   if (!data) return;
   luv_call_callback(L, data, LUV_CLOSED, 0);
   luv_cleanup_handle(L, data);
-  handle->data = NULL;
 }
 
 static int luv_close(lua_State* L) {
@@ -92,20 +91,14 @@ static int luv_close(lua_State* L) {
   return 0;
 }
 
-static void luv_gc_cb(uv_handle_t* handle) {
-  luv_close_cb(handle);
-  free(handle);
-}
-
 static int luv_handle_gc(lua_State* L) {
   uv_handle_t** udata = (uv_handle_t**)lua_touserdata(L, 1);
   uv_handle_t* handle = *udata;
   if (handle != NULL) {
-    if (!uv_is_closing(handle))
-      uv_close(handle, luv_gc_cb);
-    else
-      free(*udata);
-
+    luv_handle_t* data = handle->data;
+    if (data) free(data->extra);
+    free(data);
+    free(handle);
     *udata = NULL;
   }
 

--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -106,9 +106,7 @@ static void luv_cleanup_handle(lua_State* L, luv_handle_t* data) {
   luaL_unref(L, LUA_REGISTRYINDEX, data->ref);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callbacks[0]);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callbacks[1]);
-  if (data->extra)
-    free(data->extra);
-  free(data);
+  // The actual memory will be freed in the generic handle __gc hook
 }
 
 static void luv_find_handle(lua_State* L, luv_handle_t* data) {


### PR DESCRIPTION
We need to make type checking more robust.  Currently closed handles don't count as handles and give unexpected type errors when calling methods like `handle:is_closing()` that are expected to be safe.