### PR TITLE
Fix luv.cancel(req) so cleanup occurs in the callbacks

### DIFF
--- a/src/req.c
+++ b/src/req.c
@@ -45,8 +45,7 @@ static int luv_cancel(lua_State* L) {
   uv_req_t* req = (uv_req_t*)luv_check_req(L, 1);
   int ret = uv_cancel(req);
   if (ret < 0) return luv_error(L, ret);
-  luv_cleanup_req(L, (luv_req_t*)req->data);
-  req->data = NULL;
+  // Cleanup occurs when callbacks are ran with UV_ECANCELED status.
   lua_pushinteger(L, ret);
   return 1;
 }


### PR DESCRIPTION
Fixes issue: 

https://github.com/luvit/luv/issues/257

NOTE: The documentation says cancel is implemented for a subset of request types:

http://docs.libuv.org/en/v1.x/request.html#c.uv_cancel

This change addresses some of the callbacks, but these probably also need to be changed to check for `UV_ECANCELED`:

- `luv_poll_cb()`
- `luv_connect_cb()`
- `luv_fs_event_cb()`
- `luv_fs_poll_cb()`
- `luv_shutdown_cb()`
- `luv_connection_cb()`
- `luv_write_cb()`
- `luv_udp_send_cb()`

We might want to also change the above functions so that the callbacks are not ran if `UV_ECANCELED` is the status. In light of the fact that the documentation claims cancel only works for a subset of types, not sure how critical it is avoid calling the callbacks when a request is canceled.

Thanks,
-Brian