### PR TITLE
Allow callable tables as callback parameters (closes #265)

### DIFF
--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -53,8 +53,34 @@ static luv_handle_t* luv_setup_handle(lua_State* L) {
   return data;
 }
 
+static int luv_is_callable(lua_State* L, int index) {
+  if (luaL_getmetafield(L, index, "__call") != LUA_TNIL) {
+    // getmetatable(x).__call must be a function for x() to work
+    int callable = lua_isfunction(L, -1);
+    lua_pop(L, 1);
+    return callable;
+  }
+  return lua_isfunction(L, index);
+}
+
+static void luv_check_callable(lua_State* L, int index) {
+  if (luv_is_callable(L, index))
+    return;
+
+  const char *msg;
+  const char *typearg;  /* name for the type of the actual argument */
+  if (luaL_getmetafield(L, index, "__name") == LUA_TSTRING)
+    typearg = lua_tostring(L, -1);  /* use the given type name */
+  else if (lua_type(L, index) == LUA_TLIGHTUSERDATA)
+    typearg = "light userdata";  /* special name for messages */
+  else
+    typearg = luaL_typename(L, index);  /* standard name */
+  msg = lua_pushfstring(L, "function or callable table expected, got %s", typearg);
+  luaL_argerror(L, index, msg);
+}
+
 static void luv_check_callback(lua_State* L, luv_handle_t* data, luv_callback_id id, int index) {
-  luaL_checktype(L, index, LUA_TFUNCTION);
+  luv_check_callable(L, index);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callbacks[id]);
   lua_pushvalue(L, index);
   data->callbacks[id] = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/src/lhandle.h
+++ b/src/lhandle.h
@@ -48,6 +48,12 @@ typedef struct {
 /* Setup the handle at the top of the stack */
 static luv_handle_t* luv_setup_handle(lua_State* L);
 
+/* Return true if the object is a function or a callable table */
+static int luv_is_callable(lua_State* L, int index);
+
+/* Check if the argument is callable and throw an error if it's not */
+static void luv_check_callable(lua_State* L, int index);
+
 /* Store a lua callback in a luv_handle for future callbacks.
    Either replace an existing callback by id or append a new one at the end.
 */


### PR DESCRIPTION
`pcall` (which is used to handle the actual calling of the callbacks) handles `__call` already, so the only thing blocking this was the `LUA_TFUNCTION` type check.

Example code that will now work:
```lua
local callable = setmetatable({}, {__call=function(...) print("called", ...) end})

callable()
pcall(callable)

local uv = require('uv')

local handle = uv.new_timer()
local delay = 0
uv.timer_start(handle, delay, 0, callable)

uv.run()
```
Which outputs:
```
called  table: 0x000d8420
called  table: 0x000d8420
called  table: 0x000d8420
```

Example error when trying to pass something non-callable as a callback argument:
```
bad argument #4 to 'timer_start' (function or callable table expected, got boolean)
```

(related: #265)