### PR TITLE
fix: address argument in read/recv callback is an uninitialized string when using IPv6 addr > 16chars long

### DIFF
--- a/src/luv.h
+++ b/src/luv.h
@@ -93,7 +93,7 @@ static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf);
 static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
 
 /* from tcp.c */
-static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address, int addrlen);
+static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address);
 static void luv_connect_cb(uv_connect_t* req, int status);
 
 /* From fs.c */

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -109,17 +109,17 @@ static int luv_tcp_bind(lua_State* L) {
   return 1;
 }
 
-static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address, int addrlen) {
+static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address) {
   char ip[INET6_ADDRSTRLEN];
   int port = 0;
   lua_newtable(L);
   if (address->ss_family == AF_INET) {
     struct sockaddr_in* addrin = (struct sockaddr_in*)address;
-    uv_inet_ntop(AF_INET, &(addrin->sin_addr), ip, addrlen);
+    uv_inet_ntop(AF_INET, &(addrin->sin_addr), ip, INET6_ADDRSTRLEN);
     port = ntohs(addrin->sin_port);
   } else if (address->ss_family == AF_INET6) {
     struct sockaddr_in6* addrin6 = (struct sockaddr_in6*)address;
-    uv_inet_ntop(AF_INET6, &(addrin6->sin6_addr), ip, addrlen);
+    uv_inet_ntop(AF_INET6, &(addrin6->sin6_addr), ip, INET6_ADDRSTRLEN);
     port = ntohs(addrin6->sin6_port);
   }
 
@@ -137,7 +137,7 @@ static int luv_tcp_getsockname(lua_State* L) {
   int addrlen = sizeof(address);
   int ret = uv_tcp_getsockname(handle, (struct sockaddr*)&address, &addrlen);
   if (ret < 0) return luv_error(L, ret);
-  parse_sockaddr(L, &address, addrlen);
+  parse_sockaddr(L, &address);
   return 1;
 }
 
@@ -147,7 +147,7 @@ static int luv_tcp_getpeername(lua_State* L) {
   int addrlen = sizeof(address);
   int ret = uv_tcp_getpeername(handle, (struct sockaddr*)&address, &addrlen);
   if (ret < 0) return luv_error(L, ret);
-  parse_sockaddr(L, &address, addrlen);
+  parse_sockaddr(L, &address);
   return 1;
 }
 

--- a/src/udp.c
+++ b/src/udp.c
@@ -80,7 +80,7 @@ static int luv_udp_getsockname(lua_State* L) {
   int addrlen = sizeof(address);
   int ret = uv_udp_getsockname(handle, (struct sockaddr*)&address, &addrlen);
   if (ret < 0) return luv_error(L, ret);
-  parse_sockaddr(L, &address, addrlen);
+  parse_sockaddr(L, &address);
   return 1;
 }
 
@@ -235,7 +235,7 @@ static void luv_udp_recv_cb(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf
 
   // address
   if (addr) {
-    parse_sockaddr(L, (struct sockaddr_storage*)addr, sizeof *addr);
+    parse_sockaddr(L, (struct sockaddr_storage*)addr);
   }
   else {
     lua_pushnil(L);


### PR DESCRIPTION
fixes #271 

The issue here is that parse_sockaddr was passed `addrlen`, the length of the input address, which passes it onto `uv_inet_ntop`. However, [`uv_inet_ntop`](https://github.com/libuv/libuv/blob/1a96fe33343f82721ba8bc93adb5a67ddcf70ec4/src/inet.c#L40-L48) expects the parameter to be the _maximum length of the output string_, not the length of the input address. The length of the input data is inferred from the value of `af`. Further proof in [inet_ntop6](https://github.com/libuv/libuv/blob/1a96fe33343f82721ba8bc93adb5a67ddcf70ec4/src/inet.c#L149-L151).

Thus `parse_sockaddr` doesn't actually need a `addrlen` passed to it at all, as the input address length is encapsulated in the `sockaddr` struct.