### PR TITLE
use lua-compat-5.3 for standard APIs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lua"]
 	path = deps/lua
 	url = https://github.com/lua/lua
+[submodule "deps/lua-compat-5.3"]
+	path = deps/lua-compat-5.3
+	url = https://github.com/keplerproject/lua-compat-5.3.git

--- a/src/luv.h
+++ b/src/luv.h
@@ -50,20 +50,8 @@
 #define MAX_TITLE_LENGTH (8192)
 #endif
 
-#if LUA_VERSION_NUM < 502
-# define lua_rawlen lua_objlen
-/* lua_...uservalue: Something very different, but it should get the job done */
-# define lua_getuservalue lua_getfenv
-# define lua_setuservalue lua_setfenv
-#ifndef luaL_newlib
-# define luaL_newlib(L,l) (lua_newtable(L), luaL_register(L,NULL,l))
-#endif
-# define luaL_setfuncs(L,l,n) (assert(n==0), luaL_register(L,NULL,l))
-# define lua_resume(L,F,n) lua_resume(L,n)
-# define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)
-# define lua_absindex(L, i)                              \
-    ((i) > 0 || (i) <= LUA_REGISTRYINDEX ?              \
-     (i) : lua_gettop(L) + (i) + 1)
+#if (LUA_VERSION_NUM != 503)
+#include "../deps/lua-compat-5.3/c-api/compat-5.3.h"
 #endif
 
 /* There is a 1-1 relation between a lua_State and a uv_loop_t

--- a/src/thread.c
+++ b/src/thread.c
@@ -209,11 +209,7 @@ static const char* luv_thread_dumped(lua_State* L, int idx, size_t* l) {
     luaL_checktype(L, idx, LUA_TFUNCTION);
     lua_pushvalue(L, idx);
     luaL_buffinit(L, &b);
-#if LUA_VERSION_NUM>=503
     test_lua_dump = (lua_dump(L, thread_dump, &b, 1) == 0);
-#else
-    test_lua_dump = (lua_dump(L, thread_dump, &b) == 0);
-#endif
     if (test_lua_dump) {
       luaL_pushresult(&b);
       buff = lua_tolstring(L, -1, l);


### PR DESCRIPTION
The unified and compatible interface uses lua-compat-5.3 implementation to reduce conflicts when All In One build in luvi.