### PR TITLE
Link the libraries libpthread and libc++abi

### DIFF
--- a/deps/luajit.cmake
+++ b/deps/luajit.cmake
@@ -92,6 +92,10 @@ if ( LUA_USE_LIBM )
   list ( APPEND LIBS m )
 endif ()
 
+if ( CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  list ( APPEND LIBS pthread c++abi )
+endif ()
+
 ## SOURCES
 MACRO(LJ_TEST_ARCH stuff)
   CHECK_C_SOURCE_COMPILES("

--- a/deps/uv.cmake
+++ b/deps/uv.cmake
@@ -114,7 +114,6 @@ else()
     ${LIBUVDIR}/src/unix/pipe.c
     ${LIBUVDIR}/src/unix/poll.c
     ${LIBUVDIR}/src/unix/process.c
-    ${LIBUVDIR}/src/unix/proctitle.c
     ${LIBUVDIR}/src/unix/signal.c
     ${LIBUVDIR}/src/unix/spinlock.h
     ${LIBUVDIR}/src/unix/stream.c
@@ -181,6 +180,7 @@ if(APPLE)
     -D=_DARWIN_USE_64_BIT_INODE
   )
   set(SOURCES ${SOURCES}
+    ${LIBUVDIR}/src/unix/proctitle.c
     ${LIBUVDIR}/include/uv-darwin.h
     ${LIBUVDIR}/src/unix/bsd-ifaddrs.c
     ${LIBUVDIR}/src/unix/darwin.c


### PR DESCRIPTION
These are required for building LuaJIT on OpenBSD with clang. They provide the symbols `_Unwind_*`.