### PR TITLE
Fix /MT linker flags not being inherited by libuv subproject (#297)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,20 @@ if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x0600)
 endif (MINGW)
 
+if (WIN32)
+  # replace /MD to /MT to avoid link msvcr*.dll
+  # this needs to be before add_subdirectory calls so that they inherit the modified flags
+  set(CompilerFlags
+    CMAKE_C_FLAGS
+    CMAKE_C_FLAGS_DEBUG
+    CMAKE_C_FLAGS_MINSIZEREL
+    CMAKE_C_FLAGS_RELWITHDEBINFO
+    CMAKE_C_FLAGS_RELEASE)
+  foreach(CompilerFlag ${CompilerFlags})
+    string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+  endforeach()
+endif ()
+
 if (NOT WITH_LUA_ENGINE)
   set(WITH_LUA_ENGINE "LuaJIT"
     CACHE STRING "Link to LuaJIT or PUC Lua" FORCE)
@@ -162,16 +176,6 @@ if(WIN32)
       endif (LUA_BUILD_TYPE STREQUAL System)
     endif (USE_LUAJIT)
   endif (LUA)
-  # replace /MD to /MT to avoid link msvcr*.dll
-  set(CompilerFlags
-    CMAKE_C_FLAGS
-    CMAKE_C_FLAGS_DEBUG
-    CMAKE_C_FLAGS_MINSIZEREL
-    CMAKE_C_FLAGS_RELWITHDEBINFO
-    CMAKE_C_FLAGS_RELEASE)
-  foreach(CompilerFlag ${CompilerFlags})
-    string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-  endforeach()
 elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   target_link_libraries(luv ${LIBUV_LIBRARIES} rt)
 else()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   - luarocks remove luv
     # Test the alternate rockspec
   - mkdir build\lib
-  - cp build\Release\uv.lib build\lib
+  - cp build\deps\libuv\Release\uv_a.lib build\lib\uv.lib
   - cp -a deps\libuv\include build
   - ps: luarocks make rockspecs\$(ls rockspecs) LIBUV_DIR=build CFLAGS="/nologo /MT /O2"
   - ps: if("$(Get-Location)" -eq $(lua -e "print(require'luv'.cwd())")) { "LuaRocks test OK" } else { "LuaRocks test failed"; exit 1 }


### PR DESCRIPTION
This caused a mismatch at link time between /MD and /MT. CMAKE_C_FLAGS and friends are directory-local but inherit from the current scope when add_subdirectory is called, so we need to make sure to modify them before any add_subdirectory calls

This should fix Windows builds.