### PR TITLE
libuv: bump to 1.23.0

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -273,6 +273,10 @@ static const luaL_Reg luv_functions[] = {
 #if LUV_UV_VERSION_GEQ(1, 18, 0)
   {"os_getpid", luv_os_getpid },
 #endif
+#if LUV_UV_VERSION_GEQ(1, 23, 0)
+  {"os_getpriority", luv_os_getpriority },
+  {"os_setpriority", luv_os_setpriority },
+#endif
 
   // thread.c
   {"new_thread", luv_new_thread},

--- a/src/misc.c
+++ b/src/misc.c
@@ -457,3 +457,34 @@ static int luv_os_getpid(lua_State* L) {
   return 1;
 }
 #endif
+
+#if LUV_UV_VERSION_GEQ(1, 23, 0)
+static int luv_os_getpriority(lua_State* L) {
+  int priority;
+  uv_pid_t pid = luaL_checkinteger(L, 1);
+  int ret = uv_os_getpriority(pid, &priority);
+  if (ret == 0) {
+    lua_pushnumber(L, priority);
+    ret = 1;
+  }
+  else {
+    ret = luv_error(L, ret);
+  }
+  return ret;
+}
+#endif
+
+#if LUV_UV_VERSION_GEQ(1, 23, 0)
+static int luv_os_setpriority(lua_State* L) {
+  uv_pid_t pid = luaL_checkinteger(L, 1);
+  int priority= luaL_checkinteger(L, 2);
+  int ret = uv_os_setpriority(pid, priority);
+  if (ret == 0) {
+    lua_pushboolean(L, 1);
+    ret = 1;
+  }
+  else
+    ret = luv_error(L, ret);
+  return ret;
+}
+#endif


### PR DESCRIPTION
We do not export uv_get_osfhandle or uv_open_osfhandle yet...

Fixes: https://github.com/luvit/luv/issues/301