### PR TITLE
Fix luv_udp_recv_start error codes on Windows in Libuv <= 1.23.0

### DIFF
--- a/src/udp.c
+++ b/src/udp.c
@@ -274,6 +274,10 @@ static int luv_udp_recv_start(lua_State* L) {
   int ret;
   luv_check_callback(L, (luv_handle_t*)handle->data, LUV_RECV, 2);
   ret = uv_udp_recv_start(handle, luv_alloc_cb, luv_udp_recv_cb);
+#if LUV_UV_VERSION_LEQ(1, 23, 0)
+  // in Libuv <= 1.23.0, uv_udp_recv_start will return untranslated error codes on Windows
+  ret = uv_translate_sys_error(ret);
+#endif
   if (ret < 0) return luv_error(L, ret);
   lua_pushinteger(L, ret);
   return 1;

--- a/src/util.h
+++ b/src/util.h
@@ -22,6 +22,9 @@
 #define LUV_UV_VERSION_GEQ(major, minor, patch) \
   (((major)<<16 | (minor)<<8 | (patch)) <= UV_VERSION_HEX)
 
+#define LUV_UV_VERSION_LEQ(major, minor, patch) \
+  (((major)<<16 | (minor)<<8 | (patch)) >= UV_VERSION_HEX)
+
 void luv_stack_dump(lua_State* L, const char* name);
 static int luv_error(lua_State* L, int ret);
 static void luv_status(lua_State* L, int status);


### PR DESCRIPTION
The error code will be properly translated in the next Libuv release, see https://github.com/libuv/libuv/issues/1978

Closes #306

EDIT: CI fail is unrelated, looks like an appveyor bug.