### PR TITLE
Do not include compat-5.3.h in luv header file

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -15,6 +15,9 @@
  *
  */
 
+#if (LUA_VERSION_NUM != 503)
+#include "c-api/compat-5.3.h"
+#endif
 #include "luv.h"
 #include "util.c"
 #include "lhandle.c"

--- a/src/luv.h
+++ b/src/luv.h
@@ -50,10 +50,6 @@
 #define MAX_TITLE_LENGTH (8192)
 #endif
 
-#if (LUA_VERSION_NUM != 503)
-#include "c-api/compat-5.3.h"
-#endif
-
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"


### PR DESCRIPTION
Exposing the compat-5.3.h header file directly in the luv.h header file
is not a good idea, because it causes redefinition errors when building,
for example latest luvi version 2.8.0, with a shared luv library and
LuaJIT 2.0.5.

Therefore, include the compat header file in the luv.c source file.

Note, that luvi version 2.8.0 still fails to build against the shared luv
library using LuaJIT 2.0.5, as it does use `luaL_newlib` which is not
available in Lua 5.1. However, this is unrelated to the luv library as
luvi itself should define the macro for Lua 5.1.