### PR TITLE
Try to support extern uv_loop_t

### DIFF
--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -86,7 +86,7 @@ static void luv_check_callback(lua_State* L, luv_handle_t* data, luv_callback_id
   data->callbacks[id] = luaL_ref(L, LUA_REGISTRYINDEX);
 }
 
-static int traceback (lua_State *L) {
+static int traceback (lua_State* L) {
   if (!lua_isstring(L, 1))  /* 'message' not a string? */
     return 1;  /* keep it intact */
   lua_pushglobaltable(L);

--- a/src/luv.c
+++ b/src/luv.c
@@ -528,7 +528,7 @@ static void walk_cb(uv_handle_t *handle, void *arg)
   }
 }
 
-static int loop_gc(lua_State *L) {
+static int loop_gc(lua_State* L) {
   uv_loop_t* loop = luv_loop(L);
   // Call uv_close on every active handle
   uv_walk(loop, walk_cb, NULL);
@@ -539,7 +539,7 @@ static int loop_gc(lua_State *L) {
   return 0;
 }
 
-LUALIB_API int luaopen_luv (lua_State *L) {
+LUALIB_API int luaopen_luv (lua_State* L) {
 
   uv_loop_t* loop;
   int ret;

--- a/src/luv.c
+++ b/src/luv.c
@@ -510,14 +510,34 @@ LUALIB_API lua_State* luv_state(uv_loop_t* loop) {
   return (lua_State*)loop->data;
 }
 
-// TODO: find out if storing this somehow in an upvalue is faster
+static const char* luv_loop_key = "uv_loop";
+
 LUALIB_API uv_loop_t* luv_loop(lua_State* L) {
   uv_loop_t* loop;
-  lua_pushstring(L, "uv_loop");
+  lua_pushlightuserdata(L, (void*)luv_loop_key);
   lua_rawget(L, LUA_REGISTRYINDEX);
-  loop = (uv_loop_t*)lua_touserdata(L, -1);
+  if (lua_isnil(L, -1))
+    loop = NULL;
+  else
+    loop = *(uv_loop_t**)lua_touserdata(L, -1);
   lua_pop(L, 1);
   return loop;
+}
+
+LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop) {
+  if (loop==NULL) {
+    lua_pushlightuserdata(L, (void*)luv_loop_key);
+    lua_pushnil(L);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+  } else {
+    if (loop->data!=NULL) {
+      luaL_error(L, "uv_loop_t already attach a data");
+    }
+
+    lua_pushlightuserdata(L, (void*)luv_loop_key);
+    *((uv_loop_t**)lua_newuserdata(L, sizeof(uv_loop_t**))) = loop;
+    lua_rawset(L, LUA_REGISTRYINDEX);
+  }
 }
 
 static void walk_cb(uv_handle_t *handle, void *arg)
@@ -540,29 +560,36 @@ static int loop_gc(lua_State* L) {
 }
 
 LUALIB_API int luaopen_luv (lua_State* L) {
+  uv_loop_t* loop = luv_loop(L);
 
-  uv_loop_t* loop;
-  int ret;
+  // loop is NULL, luv need to create an inner loop
+  if (loop==NULL) {
+    int ret;
+    void* p;
 
-  // Setup the uv_loop meta table for a proper __gc
-  luaL_newmetatable(L, "uv_loop.meta");
-  lua_pushstring(L, "__gc");
-  lua_pushcfunction(L, loop_gc);
-  lua_settable(L, -3);
+    // Setup the uv_loop meta table for a proper __gc
+    luaL_newmetatable(L, "uv_loop.meta");
+    lua_pushstring(L, "__gc");
+    lua_pushcfunction(L, loop_gc);
+    lua_settable(L, -3);
 
-  loop = (uv_loop_t*)lua_newuserdata(L, sizeof(*loop));
-  ret = uv_loop_init(loop);
-  if (ret < 0) {
-    return luaL_error(L, "%s: %s\n", uv_err_name(ret), uv_strerror(ret));
+    // Push luv_loop_key as key for registry table
+    lua_pushlightuserdata(L, (void*)luv_loop_key);
+    // userdata content is: pointer of loop, and followed by loop
+    p = lua_newuserdata(L, sizeof(uv_loop_t*) + sizeof(uv_loop_t));
+    loop = (uv_loop_t*)((char*)p + sizeof(uv_loop_t*));
+    *((uv_loop_t**)p) = loop;
+    // setup the metatable for __gc
+    luaL_getmetatable(L, "uv_loop.meta");
+    lua_setmetatable(L, -2);
+    // rawset registry
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    ret = uv_loop_init(loop);
+    if (ret < 0) {
+      return luaL_error(L, "%s: %s\n", uv_err_name(ret), uv_strerror(ret));
+    }
   }
-  // setup the metatable for __gc
-  luaL_getmetatable(L, "uv_loop.meta");
-  lua_setmetatable(L, -2);
-  // Tell the state how to find the loop.
-  lua_pushstring(L, "uv_loop");
-  lua_insert(L, -2);
-  lua_rawset(L, LUA_REGISTRYINDEX);
-  lua_pop(L, 1);
 
   // Tell the loop how to find the state.
   loop->data = L;

--- a/src/luv.h
+++ b/src/luv.h
@@ -68,7 +68,7 @@ LUALIB_API uv_loop_t* luv_loop(lua_State* L);
    This can be called multiple times in a process as long
    as you use a different lua_State and thread for each.
 */
-LUALIB_API int luaopen_luv (lua_State *L);
+LUALIB_API int luaopen_luv (lua_State* L);
 
 #include "util.h"
 #include "lhandle.h"
@@ -77,7 +77,7 @@ LUALIB_API int luaopen_luv (lua_State *L);
 /* From stream.c */
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
-static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf);
+static void luv_check_buf(lua_State* L, int idx, uv_buf_t *pbuf);
 static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
 
 /* from tcp.c */

--- a/src/luv.h
+++ b/src/luv.h
@@ -54,15 +54,22 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
+
 /* There is a 1-1 relation between a lua_State and a uv_loop_t
    These helpers will give you one if you have the other
    These are exposed for extensions built with luv
    This allows luv to be used in multithreaded applications.
 */
 LUALIB_API lua_State* luv_state(uv_loop_t* loop);
-/* All libuv callbacks will lua_call directly from this root-per-thread state
-*/
+
+/* All libuv callbacks will lua_call directly from this root-per-thread state */
 LUALIB_API uv_loop_t* luv_loop(lua_State* L);
+
+/* Set an extern uv_loop_t in a lua_State
+   This must be called before luaopen_luv, luaopen_luv don't init an inner loop
+   When loop is NULL, will clear previous extern loop
+*/
+LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop);
 
 /* This is the main hook to load the library.
    This can be called multiple times in a process as long

--- a/src/process.c
+++ b/src/process.c
@@ -38,7 +38,7 @@ static void exit_cb(uv_process_t* handle, int64_t exit_status, int term_signal) 
 }
 
 static void luv_spawn_close_cb(uv_handle_t* handle) {
-  lua_State *L = luv_state(handle->loop);
+  lua_State* L = luv_state(handle->loop);
   luv_unref_handle(L, (luv_handle_t*)handle->data);
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -16,7 +16,7 @@
  */
 #include "luv.h"
 
-static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf) {
+static void luv_check_buf(lua_State* L, int idx, uv_buf_t *pbuf) {
     size_t len;
     pbuf->base = (char*)luaL_checklstring(L, idx, &len);
     pbuf->len = len;

--- a/src/thread.c
+++ b/src/thread.c
@@ -257,7 +257,7 @@ static void luv_thread_cb(void* varg) {
   //push lua function, thread entry
   if (luaL_loadbuffer(L, thd->code, thd->len, "=thread") == 0) {
     int i, ret;
-    
+
     //push parameter for real thread function
     i = luv_thread_arg_push(L, &thd->arg, LUVF_THREAD_UHANDLE);
     assert(i == thd->arg.argc);

--- a/src/udp.c
+++ b/src/udp.c
@@ -171,7 +171,7 @@ static void luv_udp_send_cb(uv_udp_send_t* req, int status) {
   req->data = NULL;
 }
 
-static struct sockaddr* luv_check_addr(lua_State *L, struct sockaddr_storage* addr, int hostidx, int portidx) {
+static struct sockaddr* luv_check_addr(lua_State* L, struct sockaddr_storage* addr, int hostidx, int portidx) {
   const char* host;
   int port;
 #if LUV_UV_VERSION_GEQ(1, 27, 0)

--- a/src/work.c
+++ b/src/work.c
@@ -42,7 +42,7 @@ static luv_work_ctx_t* luv_check_work_ctx(lua_State* L, int index)
   return ctx;
 }
 
-static int luv_work_ctx_gc(lua_State *L)
+static int luv_work_ctx_gc(lua_State* L)
 {
   luv_work_ctx_t* ctx = luv_check_work_ctx(L, 1);
   free(ctx->code);
@@ -65,7 +65,7 @@ static void luv_work_cb(uv_work_t* req)
 
   luv_work_t* work = (luv_work_t*)req->data;
   luv_work_ctx_t* ctx = work->ctx;
-  lua_State *L = (lua_State *)uv_key_get(&L_key);
+  lua_State* L = (lua_State*)uv_key_get(&L_key);
 
   if (L == NULL) {
     /* vm reuse in threadpool */
@@ -144,7 +144,7 @@ static void luv_work_cb(uv_work_t* req)
 static void luv_after_work_cb(uv_work_t* req, int status) {
   luv_work_t* work = (luv_work_t*)req->data;
   luv_work_ctx_t* ctx = work->ctx;
-  lua_State*L = ctx->L;
+  lua_State* L = ctx->L;
   int i, errfunc, ret;
   (void)status;
 


### PR DESCRIPTION
Ok, https://github.com/luvit/luv/issues/252 and https://github.com/neovim/neovim/pull/9546 hope luv use extern uv_loop_t created by other c libs. Let me try it.  please look at https://github.com/luvit/luv/commit/1241556cc5b6293a053b87ddaef4c01fe97e9922.

How to use.

1. create your uv_loop_t* loop out of luv.
2. call luv_set_loop(L, loop) before luaopen_luv.
3. call luvopen_luv, luvopen_luv will check wether need to create loop in luv. loop outside of luv will not be gc. so caller should manage it.
