### PR TITLE
allow embedder to control the execution and error handling of callbacks

### DIFF
--- a/src/luv.h
+++ b/src/luv.h
@@ -69,6 +69,9 @@ LUALIB_API uv_loop_t* luv_loop(lua_State* L);
 */
 LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop);
 
+typedef void (*luv_cb_hook_t)(lua_State *L, int nargs);
+LUALIB_API void luv_set_cb_hook(lua_State* L, luv_cb_hook_t hook);
+
 /* This is the main hook to load the library.
    This can be called multiple times in a process as long
    as you use a different lua_State and thread for each.
@@ -80,6 +83,9 @@ LUALIB_API int luaopen_luv (lua_State *L);
 #include "lreq.h"
 
 #ifdef LUV_SOURCE
+
+static luv_cb_hook_t luv_cb_hook(lua_State* L);
+
 /* From stream.c */
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);


### PR DESCRIPTION
For effecient use in neovim we would need a bit of control how luv executes callbacks. 

Primarily we need to take control of handling of errors. Currently luv prints errors in callbacks directly to stderr which messes up the internal screen of nvim. But we would also like to set a flag around the execution of the callback, as some lua API functions in nvim need to behave differently inside a luv callback (to avoid nested event loop for instance).

My suggestion is to add a "hook" function that a C embedder can set in a similar way to setting the event loop. Then the embedder is responsible for executing the callback and dealing with errors, including potential formatting of tracebacks etc. https://github.com/neovim/neovim/pull/10316/commits/aa78c74b74c6a0e3595b76d02f674dacabd6e092 is an example of usage.

Does this seem reasonable? if so I can clean up the patch, and add docs etc.