### PR TITLE
rockspec: LIBUV: specify library='uv'

### DIFF
--- a/rockspecs/luv-scm-0.rockspec
+++ b/rockspecs/luv-scm-0.rockspec
@@ -23,7 +23,8 @@ dependencies = {
 
 external_dependencies = {
   LIBUV = {
-    header = 'uv.h'
+    header = 'uv.h',
+    library = 'uv',
   },
   LUA_COMPAT53 = {
     header = "c-api/compat-5.3.h"


### PR DESCRIPTION
This is required for LuaRocks to find libuv on Windows.

Ref: https://github.com/neovim/neovim/pull/10292#issuecomment-506924822

/cc @erw7