### PR TITLE
Provide package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,14 @@ if (CMAKE_INSTALL_PREFIX)
     LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   )
   if (NOT BUILD_MODULE)
+    if(UNIX)
+      set(prefix ${CMAKE_INSTALL_PREFIX})
+      set(includedir ${INSTALL_INC_DIR})
+      set(libdir ${INSTALL_LIB_DIR})
+      configure_file(libluv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libluv.pc @ONLY)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libluv.pc
+        DESTINATION ${INSTALL_LIB_DIR}/pkgconfig)
+    endif()
     install(
       FILES src/luv.h src/util.h src/lhandle.h src/lreq.h
       DESTINATION "${INSTALL_INC_DIR}"

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ luv: build/Makefile
 	cmake --build build --config Debug
 	ln -sf build/luv.so
 
+install: luv
+	make -C build install
+
 clean:
 	rm -rf build luv.so
 

--- a/libluv.pc.in
+++ b/libluv.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libluv
+Version: @LUV_VERSION@
+Description: Bare and full libuv bindings for Lua/LuaJIT.
+URL: https://github.com/luvit/luv
+
+Libs: -L${libdir} -lluv @LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
This helps the development of other programs using LUV.

`make BUILD_MODULE=0 install` will install libluv.a and libluv.pc