### PR TITLE
Fix callable tables as callback parameters for luv_req_t and add tests

### DIFF
--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -54,32 +54,6 @@ static luv_handle_t* luv_setup_handle(lua_State* L, luv_ctx_t* ctx) {
   return data;
 }
 
-static int luv_is_callable(lua_State* L, int index) {
-  if (luaL_getmetafield(L, index, "__call") != LUA_TNIL) {
-    // getmetatable(x).__call must be a function for x() to work
-    int callable = lua_isfunction(L, -1);
-    lua_pop(L, 1);
-    return callable;
-  }
-  return lua_isfunction(L, index);
-}
-
-static void luv_check_callable(lua_State* L, int index) {
-  const char *msg;
-  const char *typearg;  /* name for the type of the actual argument */
-  if (luv_is_callable(L, index))
-    return;
-
-  if (luaL_getmetafield(L, index, "__name") == LUA_TSTRING)
-    typearg = lua_tostring(L, -1);  /* use the given type name */
-  else if (lua_type(L, index) == LUA_TLIGHTUSERDATA)
-    typearg = "light userdata";  /* special name for messages */
-  else
-    typearg = luaL_typename(L, index);  /* standard name */
-  msg = lua_pushfstring(L, "function or callable table expected, got %s", typearg);
-  luaL_argerror(L, index, msg);
-}
-
 static void luv_check_callback(lua_State* L, luv_handle_t* data, luv_callback_id id, int index) {
   luv_check_callable(L, index);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callbacks[id]);

--- a/src/lhandle.h
+++ b/src/lhandle.h
@@ -53,12 +53,6 @@ static int luv_traceback (lua_State *L);
 /* Setup the handle at the top of the stack */
 static luv_handle_t* luv_setup_handle(lua_State* L, luv_ctx_t* ctx);
 
-/* Return true if the object is a function or a callable table */
-static int luv_is_callable(lua_State* L, int index);
-
-/* Check if the argument is callable and throw an error if it's not */
-static void luv_check_callable(lua_State* L, int index);
-
 /* Store a lua callback in a luv_handle for future callbacks.
    Either replace an existing callback by id or append a new one at the end.
 */

--- a/src/lreq.c
+++ b/src/lreq.c
@@ -19,7 +19,7 @@
 
 static int luv_check_continuation(lua_State* L, int index) {
   if (lua_isnoneornil(L, index)) return LUA_NOREF;
-  luaL_checktype(L, index, LUA_TFUNCTION);
+  luv_check_callable(L, index);
   lua_pushvalue(L, index);
   return luaL_ref(L, LUA_REGISTRYINDEX);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -30,6 +30,12 @@ void luv_stack_dump(lua_State* L, const char* name);
 #ifdef LUV_SOURCE
 static int luv_error(lua_State* L, int ret);
 static void luv_status(lua_State* L, int status);
+
+/* Return true if the object is a function or a callable table */
+static int luv_is_callable(lua_State* L, int index);
+
+/* Check if the argument is callable and throw an error if it's not */
+static void luv_check_callable(lua_State* L, int index);
 #endif
 
 #endif

--- a/tests/test-callbacks.lua
+++ b/tests/test-callbacks.lua
@@ -1,0 +1,55 @@
+return require('lib/tap')(function (test)
+
+  -- Notes:
+  -- * When using a callable table as a callback, it will get itself as the first param when it is called.
+  --   This matches what happens when calling the callable table normally.
+  -- * expect wraps its argument in a function and returns the function, so expect should not be called on
+  --   a callable table directly.
+
+  test("luv_handle_t: function", function (print, p, expect, uv)
+    local handle = uv.new_timer()
+
+    local function onclose()
+      p("closed", handle)
+    end
+    local function ontimeout()
+      p("timeout", handle)
+      uv.close(handle, expect(onclose))
+    end
+
+    uv.timer_start(handle, 10, 0, expect(ontimeout))
+  end)
+
+  test("luv_handle_t: callable table", function (print, p, expect, uv)
+    local handle = uv.new_timer()
+
+    local function onclose(self)
+      p("closed", self, handle)
+    end
+    local onCloseTable = setmetatable({}, {__call=expect(onclose)})
+
+    local function ontimeout(self)
+      p("timeout", self, handle)
+      uv.close(handle, onCloseTable)
+    end
+    local onTimeoutTable = setmetatable({}, {__call=expect(ontimeout)})
+
+    uv.timer_start(handle, 10, 0, onTimeoutTable)
+  end)
+
+  test("luv_req_t: function", function (print, p, expect, uv)
+    local fn = function(err, path)
+      p(err, path)
+    end
+    assert(uv.fs_realpath('.', expect(fn)))
+  end)
+
+  test("luv_req_t: callable table", function (print, p, expect, uv)
+    local fn = function(self, err, path)
+      p(self, err, path)
+    end
+    local callable = setmetatable({}, {__call=expect(fn)})
+    assert(uv.fs_realpath('.', callable))
+  end)
+
+end)


### PR DESCRIPTION
Follow up to #266, which made callable tables work for `luv_handle_t`, but accidentally forgot to apply the same thing to `luv_req_t`

Related: #265.