### PR TITLE
src/luv.c: include lua.h

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include <lua.h>
 #if (LUA_VERSION_NUM != 503)
 #include "c-api/compat-5.3.h"
 #endif


### PR DESCRIPTION
lua.h must be included before checking for LUA_VERSION_NUM otherwise we
won't get the version and compat-5.3.h will always be needed

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>