### PR TITLE
Fix os_setenv/os_unsetenv returning an error when they succeed

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -392,9 +392,9 @@ static int luv_os_setenv(lua_State* L) {
   const char* value = luaL_checkstring(L, 2);
   int ret = uv_os_setenv(name, value);
   if (ret == 0)
-    return luv_error(L, ret);
-  else
     lua_pushboolean(L, 1);
+  else
+    return luv_error(L, ret);
   return 1;
 }
 
@@ -402,9 +402,9 @@ static int luv_os_unsetenv(lua_State* L) {
   const char* name = luaL_checkstring(L, 1);
   int ret = uv_os_unsetenv(name);
   if (ret == 0)
-    return luv_error(L, ret);
-  else
     lua_pushboolean(L, 1);
+  else
+    return luv_error(L, ret);
   return 1;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -40,6 +40,7 @@ void luv_stack_dump(lua_State* L, const char* name) {
 }
 
 static int luv_error(lua_State* L, int status) {
+  assert(status < 0);
   lua_pushnil(L);
   lua_pushfstring(L, "%s: %s", uv_err_name(status), uv_strerror(status));
   lua_pushstring(L, uv_err_name(status));

--- a/tests/test-misc.lua
+++ b/tests/test-misc.lua
@@ -124,8 +124,8 @@ return require('lib/tap')(function (test)
     local name, name2 = "LUV_TEST_FOO", "LUV_TEST_FOO2";
     local value, value2 = "123456789", ""
 
-    uv.os_setenv(name, value)
-    uv.os_setenv(name2, value2)
+    assert(uv.os_setenv(name, value))
+    assert(uv.os_setenv(name2, value2))
 
     local env = uv.os_environ();
     assert(env[name]==value)


### PR DESCRIPTION
Without this patch, the added asserts in the test case would fail with:

```
  tests/test-misc.lua:127: Unknown system error 0: Unknown system error 0
  stack traceback:
        [C]: in function 'assert'
        tests/test-misc.lua:127: in function 'fn'
        ./lib/tap.lua:53: in function <./lib/tap.lua:42>
        [C]: in function 'xpcall'
        ./lib/tap.lua:42: in function 'run'
        ./lib/tap.lua:136: in function <./lib/tap.lua:113>
        [C]: at 0x00405680
not ok 18 uv.os_environ
```