### PR TITLE
Fix some tests failing when run on their own on Windows

### DIFF
--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -12,6 +12,14 @@ else
   usecolors = false
 end
 
+if _G.jit and _G.jit.os then
+  -- Luajit provides explicit platform detection
+  utils.isWindows = _G.jit.os == "Windows"
+else
+  -- Normal lua will only have \ for path separator on windows.
+  utils.isWindows = package.config:find("\\") and true or false
+end
+
 local colors = {
   black   = "0;30",
   red     = "0;31",

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -6,16 +6,6 @@
 local tap = require("lib/tap")
 local uv = require("luv")
 
-local isWindows
-if jit and jit.os then
-  -- Luajit provides explicit platform detection
-  isWindows = jit.os == "Windows"
-else
-  -- Normal lua will only have \ for path separator on windows.
-  isWindows = package.config:find("\\") and true or false
-end
-_G.isWindows = isWindows
-
 local req = uv.fs_scandir("tests")
 
 while true do

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -1,5 +1,7 @@
 return require('lib/tap')(function (test)
 
+  local isWindows = require('lib/utils').isWindows
+
   local function errorAllowed(err)
     -- allowed errors  from gnulib's test-getaddrinfo.c
     return err == "EAI_AGAIN" -- offline/no network connection
@@ -47,7 +49,7 @@ return require('lib/tap')(function (test)
   end)
 
   -- FIXME: this test always fails on AppVeyor for some reason
-  if _G.isWindows and not os.getenv'APPVEYOR' then
+  if isWindows and not os.getenv'APPVEYOR' then
     test("Get only ipv6 tcp adresses for luvit.io", function (print, p, expect, uv)
       assert(uv.getaddrinfo("luvit.io", nil, {
         socktype = "stream",

--- a/tests/test-process.lua
+++ b/tests/test-process.lua
@@ -1,16 +1,6 @@
 return require('lib/tap')(function (test)
 
-  local isWindows =  _G.isWindows
-  -- needed to make test-process able to run on its own
-  if isWindows == nil then
-    if _G.jit and _G.jit.os then
-      -- Luajit provides explicit platform detection
-      isWindows = _G.jit.os == "Windows"
-    else
-      -- Normal lua will only have \ for path separator on windows.
-      isWindows = package.config:find("\\") and true or false
-    end
-  end
+  local isWindows = require('lib/utils').isWindows
 
   test("test disable_stdio_inheritance", function (print, p, expect, uv)
     uv.disable_stdio_inheritance()

--- a/tests/test-process.lua
+++ b/tests/test-process.lua
@@ -1,6 +1,16 @@
 return require('lib/tap')(function (test)
 
   local isWindows =  _G.isWindows
+  -- needed to make test-process able to run on its own
+  if isWindows == nil then
+    if _G.jit and _G.jit.os then
+      -- Luajit provides explicit platform detection
+      isWindows = _G.jit.os == "Windows"
+    else
+      -- Normal lua will only have \ for path separator on windows.
+      isWindows = package.config:find("\\") and true or false
+    end
+  end
 
   test("test disable_stdio_inheritance", function (print, p, expect, uv)
     uv.disable_stdio_inheritance()

--- a/tests/test-signal.lua
+++ b/tests/test-signal.lua
@@ -11,7 +11,7 @@ end)
 
 return require('lib/tap')(function (test)
 
-  if _G.isWindows then return end
+  if require('lib/utils').isWindows then return end
 
   test("Catch SIGINT", function (print, p, expect, uv)
     local child, pid


### PR DESCRIPTION
`_G.isWindows` only gets set in tests/run.lua so running test-process.lua directly means `isWindows` would be nil on Windows