### PR TITLE
tap: Only call os.exit on failure

### DIFF
--- a/lib/tap.lua
+++ b/lib/tap.lua
@@ -104,7 +104,9 @@ local function run()
   uv.walk(uv.close)
   uv.run()
 
-  os.exit(-failed)
+  if failed ~= 0 then
+    os.exit(-failed)
+  end
 end
 
 local single = true


### PR DESCRIPTION
os.exit bypasses things like lua_close, so calling it on success makes it harder to evaluate if memory is getting leaked when tests pass