### PR TITLE
Fix various bugs with argument order/strictness/etc

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -253,6 +253,10 @@ static int luv_spawn(lua_State* L) {
   lua_pop(L, 1);
 #endif
 
+  // this will fill the 3rd argument with nil if it doesn't exist so that
+  // the uv_process_t userdata doesn't get treated as the 3rd argument
+  lua_settop(L, 3);
+
   handle = (uv_process_t*)luv_newuserdata(L, sizeof(*handle));
   handle->type = UV_PROCESS;
   handle->data = luv_setup_handle(L, ctx);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -32,7 +32,7 @@ static int luv_new_tcp(lua_State* L) {
     ret = uv_tcp_init(ctx->loop, handle);
   }
   else {
-    ret = uv_tcp_init_ex(ctx->loop, handle, lua_tointeger(L, 1));
+    ret = uv_tcp_init_ex(ctx->loop, handle, luaL_checkinteger(L, 1));
   }
   if (ret < 0) {
     lua_pop(L, 1);

--- a/src/thread.c
+++ b/src/thread.c
@@ -260,13 +260,6 @@ static int luv_new_thread(lua_State* L) {
 #if LUV_UV_VERSION_GEQ(1, 26, 0)
   uv_thread_options_t options;
   options.flags = UV_THREAD_NO_FLAGS;
-#endif
-  thread = (luv_thread_t*)lua_newuserdata(L, sizeof(*thread));
-  memset(thread, 0, sizeof(*thread));
-  luaL_getmetatable(L, "uv_thread");
-  lua_setmetatable(L, -2);
-
-#if LUV_UV_VERSION_GEQ(1, 26, 0)
   if (lua_type(L, 1) == LUA_TTABLE)
   {
     cbidx++;
@@ -287,6 +280,11 @@ static int luv_new_thread(lua_State* L) {
 #endif
 
   buff = luv_thread_dumped(L, cbidx, &len);
+
+  thread = (luv_thread_t*)lua_newuserdata(L, sizeof(*thread));
+  memset(thread, 0, sizeof(*thread));
+  luaL_getmetatable(L, "uv_thread");
+  lua_setmetatable(L, -2);
 
   //clear in luv_thread_gc or in child threads
   thread->argc = luv_thread_arg_set(L, &thread->arg, cbidx+1, lua_gettop(L) - 1, LUVF_THREAD_UHANDLE);

--- a/src/udp.c
+++ b/src/udp.c
@@ -24,13 +24,14 @@ static uv_udp_t* luv_check_udp(lua_State* L, int index) {
 
 static int luv_new_udp(lua_State* L) {
   luv_ctx_t* ctx = luv_context(L);
+  lua_settop(L, 1);
   uv_udp_t* handle = (uv_udp_t*)luv_newuserdata(L, sizeof(*handle));
   int ret;
   if (lua_isnoneornil(L, 1)) {
     ret = uv_udp_init(ctx->loop, handle);
   }
   else {
-    ret = uv_udp_init_ex(ctx->loop, handle, lua_tointeger(L, 1));
+    ret = uv_udp_init_ex(ctx->loop, handle, luaL_checkinteger(L, 1));
   }
   if (ret < 0) {
     lua_pop(L, 1);


### PR DESCRIPTION
Went through all instances of `luv_newuserdata` to find things similar to #390 and fixed them all.

Before:
```lua
uv.new_thread() -- bad argument #1 to 'new_thread' (function expected, got userdata)
uv.spawn("", {}) -- bad argument #3 to 'spawn' (function or callable table expected, got uv_process)
uv.new_tcp("test") -- this would coerce the string into an int
uv.new_udp() -- this would always call uv_udp_init_ex and use the uv_udp_t userdata as the arg (coerced to 0)
```

After:
```lua
uv.new_thread() -- bad argument #1 to 'new_thread' (function expected, got no value)
uv.spawn("", {}) -- no error, 3rd argument is meant to be optional
uv.new_tcp("test") -- bad argument #1 to 'new_tcp' (number expected, got string)
uv.new_udp() -- this now correctly calls uv_udp_init instead of uv_udp_init_ex, has same error as above if non-number is given as the first arg
```