### PR TITLE
Modify test-signal to avoid os.exit

### DIFF
--- a/tests/test-signal.lua
+++ b/tests/test-signal.lua
@@ -32,8 +32,9 @@ return require('lib/tap')(function (test)
       if chunk then
         p(chunk)
         assert(chunk=="sigint\n")
+        uv.read_stop(output)
       end
-    end, 2))
+    end, 1))
     uv.write(input, child_code)
     uv.shutdown(input)
     local timer = uv.new_timer()


### PR DESCRIPTION
Use stdout to check that sigint was handled by the child process instead of the exit code of the child

This partially addresses #382 (see https://github.com/luvit/luv/issues/382#issuecomment-539765951). With this PR, LSAN does not detect any leaks during `tests/run.lua` for me.