### PR TITLE
Remove MSVC 2013 jobs from appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,10 @@
 os: Visual Studio 2015
 
-# Test with the latest two releases of MSVC
+# MSVC versions
 configuration:
   - 2015
-  - 2013
 
-# Test with the latest Lua and LuaJIT versions
+# Lua, LuaJIT, Luarocks versions
 environment:
   matrix:
     # LuaRocks 3.1.3


### PR DESCRIPTION
This should cut the time it takes to run Appveyor CI in half (from ~50 minutes to ~25 minutes) and MSVC 2013 is old enough to stop running CI for I think (and even 2015 might be worth changing to 2017?).

EDIT: Related: https://github.com/luvit/luv/pull/344#issuecomment-515631371