### PR TITLE
Fix uninitialised var warning in new_tcp/new_udp

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -32,7 +32,7 @@ static int luv_new_tcp(lua_State* L) {
     ret = uv_tcp_init(ctx->loop, handle);
   }
   else {
-    unsigned int flags;
+    unsigned int flags = AF_UNSPEC;
     if (lua_isnumber(L, 1)) {
       flags = lua_tointeger(L, 1);
     }

--- a/src/udp.c
+++ b/src/udp.c
@@ -31,7 +31,7 @@ static int luv_new_udp(lua_State* L) {
     ret = uv_udp_init(ctx->loop, handle);
   }
   else {
-    unsigned int flags;
+    unsigned int flags = AF_UNSPEC;
     if (lua_isnumber(L, 1)) {
       flags = lua_tointeger(L, 1);
     }


### PR DESCRIPTION
Closes #398

(was a false-positive)