### PR TITLE
Fixes returning of send/recv buffer size

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -151,34 +151,36 @@ static int luv_has_ref(lua_State* L) {
 
 static int luv_send_buffer_size(lua_State* L) {
   uv_handle_t* handle = luv_check_handle(L, 1);
-  int value;
+  int value = luaL_optinteger(L, 2, 0);
   int ret;
-  if (lua_isnoneornil(L, 2)) {
-    value = 0;
+  if (value == 0) { // get
+    ret = uv_send_buffer_size(handle, &value);
+    if (ret < 0) return luv_error(L, ret);
+    lua_pushinteger(L, value);
+    return 1;
+  } else { // set
+    ret = uv_send_buffer_size(handle, &value);
+    if (ret < 0) return luv_error(L, ret);
+    lua_pushinteger(L, ret);
+    return 1;
   }
-  else {
-    value = luaL_checkinteger(L, 2);
-  }
-  ret = uv_send_buffer_size(handle, &value);
-  if (ret < 0) return luv_error(L, ret);
-  lua_pushinteger(L, ret);
-  return 1;
 }
 
 static int luv_recv_buffer_size(lua_State* L) {
   uv_handle_t* handle = luv_check_handle(L, 1);
-  int value;
+  int value = luaL_optinteger(L, 2, 0);
   int ret;
-  if (lua_isnoneornil(L, 2)) {
-    value = 0;
+  if (value == 0) { // get
+    ret = uv_recv_buffer_size(handle, &value);
+    if (ret < 0) return luv_error(L, ret);
+    lua_pushinteger(L, value);
+    return 1;
+  } else { // set
+    ret = uv_recv_buffer_size(handle, &value);
+    if (ret < 0) return luv_error(L, ret);
+    lua_pushinteger(L, ret);
+    return 1;
   }
-  else {
-    value = luaL_checkinteger(L, 2);
-  }
-  ret = uv_recv_buffer_size(handle, &value);
-  if (ret < 0) return luv_error(L, ret);
-  lua_pushinteger(L, ret);
-  return 1;
 }
 
 static int luv_fileno(lua_State* L) {


### PR DESCRIPTION
Fixes #404  

Test:
```lua
local socket = uv.new_udp()
local size = 4096
local mult = jit.os == 'Linux' and 2 or 1

assert('udp bind', uv.udp_bind(socket, "0.0.0.0", 9123))

assert(uv.send_buffer_size(socket) == uv.send_buffer_size(socket, 0))
assert(uv.send_buffer_size(socket, size) == 0)
assert(uv.send_buffer_size(socket) == size * mult)

assert(uv.recv_buffer_size(socket) == uv.recv_buffer_size(socket, 0))
assert(uv.recv_buffer_size(socket, size) == 0)
assert(uv.recv_buffer_size(socket) == size * mult)
```

I'd say add this to the test suite, but the behavior is annoyingly platform dependent. The size can be silently doubled or clamped, so there's no strong guarantee on what happens. I thought libuv is supposed to iron this stuff out.

Libuv code for reference:

- https://github.com/libuv/libuv/blob/645be48a804e1538d6058fa147d8786c49baf94b/src/uv-common.c#L543-L549
- https://github.com/libuv/libuv/blob/59146f2f4bea7b692238103a8a8e82c4bdc1fc2b/src/unix/core.c#L193-L219
