### PR TITLE
Fix luv_backend_fd returning "Unknown system error" on Windows

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -51,7 +51,10 @@ static int luv_stop(lua_State* L) {
 
 static int luv_backend_fd(lua_State* L) {
   int ret = uv_backend_fd(luv_loop(L));
-  lua_pushinteger(L, ret);
+  if (ret == -1)
+    lua_pushnil(L);
+  else
+    lua_pushinteger(L, ret);
   return 1;
 }
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -51,6 +51,7 @@ static int luv_stop(lua_State* L) {
 
 static int luv_backend_fd(lua_State* L) {
   int ret = uv_backend_fd(luv_loop(L));
+  // -1 is returned when there is no backend fd (like on Windows)
   if (ret == -1)
     lua_pushnil(L);
   else

--- a/src/loop.c
+++ b/src/loop.c
@@ -51,7 +51,6 @@ static int luv_stop(lua_State* L) {
 
 static int luv_backend_fd(lua_State* L) {
   int ret = uv_backend_fd(luv_loop(L));
-  if (ret < 0) return luv_error(L, ret);
   lua_pushinteger(L, ret);
   return 1;
 }


### PR DESCRIPTION
`uv_backend_fd` returns a bare -1 (not an error code) on Windows, so interpreting it as an error code is wrong. This is similar to how `luv_backend_timeout` is bound (which also can return a bare -1)

```lua
print(uv.backend_fd())
-- before
nil     Unknown system error -1: Unknown system error -1        Unknown system error -1
-- after
nil
```

This is just one simple way to fix this. Returning -1 doesn't feel like the best way to bind this, though. Open to suggestions (that we'd also apply to `luv_backend_timeout`)

EDIT: Now returns nil, see comments below.

Relevant comments:
- https://github.com/luvit/luv/pull/403#issuecomment-540273026
- https://github.com/luvit/luv/pull/403#issuecomment-540864344