### PR TITLE
Fix tcp_close_reset returning inconsistent values on success

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -213,11 +213,7 @@ static int luv_tcp_close_reset(lua_State* L) {
     luv_check_callback(L, (luv_handle_t*)handle->data, LUV_RESET, 2);
   }
   ret = uv_tcp_close_reset(handle, luv_close_reset_cb);
-  if (ret < 0) {
-    lua_pop(L, 1);
-    return luv_error(L, ret);
-  }
-  return 1;
+  return luv_result(L, ret);
 }
 #endif
 


### PR DESCRIPTION
It would just return whatever happens to be at the top of the stack (the last argument passed to tcp_close_reset), now it returns the result consistent with other functions

EDIT: To address a potential concern, the `lua_pop` was just a copy+paste artifact--it's not necessary

Related to comments in #409