### PR TITLE
Remove c-api directory from #include for compat-5.3.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - mkdir build/lib
   - cp build/deps/libuv/libuv_a.a build/lib/libuv.a
   - cp -a deps/libuv/include build
-  - luarocks make rockspecs/$(ls rockspecs) LIBUV_DIR=build LUA_COMPAT53_INCDIR=deps/lua-compat-5.3
+  - luarocks make rockspecs/$(ls rockspecs) LIBUV_DIR=build LUA_COMPAT53_INCDIR=deps/lua-compat-5.3/c-api
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if(APPLE)
 endif()
 
 if(NOT LUA_COMPAT53_DIR)
-  set(LUA_COMPAT53_DIR deps/lua-compat-5.3)
+  set(LUA_COMPAT53_DIR deps/lua-compat-5.3/c-api)
 endif()
 if(DEFINED ENV{LUA_COMPAT53_DIR})
   set(LUA_COMPAT53_DIR $ENV{LUA_COMPAT53_DIR})

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_SHARED_LIBS ?= OFF
 WITH_SHARED_LIBUV ?= OFF
 WITH_LUA_ENGINE ?= LuaJIT
 LUA_BUILD_TYPE ?= Static
-LUA_COMPAT53_DIR ?= deps/lua-compat-5.3
+LUA_COMPAT53_DIR ?= deps/lua-compat-5.3/c-api
 
 ifeq ($(WITH_LUA_ENGINE), LuaJIT)
   LUABIN=build/luajit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,6 @@ for:
   - mkdir build\lib
   - cp build.luarocks\deps\libuv\Release\uv_a.lib build\lib\uv.lib
   - cp -a deps\libuv\include build
-  - ps: luarocks make rockspecs\$(ls rockspecs) LIBUV_DIR=build LUA_COMPAT53_INCDIR=deps/lua-compat-5.3 CFLAGS="/nologo /MT /O2"
+  - ps: luarocks make rockspecs\$(ls rockspecs) LIBUV_DIR=build LUA_COMPAT53_INCDIR=deps/lua-compat-5.3/c-api CFLAGS="/nologo /MT /O2"
   - ps: if("$(Get-Location)" -eq $(lua -e "print(require'luv'.cwd())")) { "LuaRocks test OK" } else { "LuaRocks test failed"; exit 1 }
   - luarocks remove luv

--- a/rockspecs/luv-scm-0.rockspec
+++ b/rockspecs/luv-scm-0.rockspec
@@ -27,7 +27,7 @@ external_dependencies = {
     library = 'uv',
   },
   LUA_COMPAT53 = {
-    header = "c-api/compat-5.3.h"
+    header = "compat-5.3.h"
   }
 }
 

--- a/src/luv.c
+++ b/src/luv.c
@@ -17,7 +17,7 @@
 
 #include <lua.h>
 #if (LUA_VERSION_NUM != 503)
-#include "c-api/compat-5.3.h"
+#include "compat-5.3.h"
 #endif
 #define LUV_SOURCE
 #include "luv.h"


### PR DESCRIPTION
This better matches how it would be found when building against system-installed lua-compat53.

---
I realize there's not a _ton_ of precedence here, since a lot of packages simply vendor lua-compat53, but Debian's [codesearch](https://codesearch.debian.net/search?q=compat-5%5C.3%5C.h+-pkg%3Alua-compat53+-path%3A.*compat-5%5C.3%5C.c&literal=1) shows a general trend.