### PR TITLE
tap: Make os.exit call lua_close on Lua versions that support it

### DIFF
--- a/lib/tap.lua
+++ b/lib/tap.lua
@@ -105,7 +105,7 @@ local function run()
   uv.run()
 
   if failed ~= 0 then
-    os.exit(-failed)
+    os.exit(-failed, true)
   end
 end
 


### PR DESCRIPTION
Second optional argument to os.exit is a boolean that determines if lua_close should be called while exiting. This was added in PUC Lua 5.2 and backported to LuaJIT.

This allows the tests to provide accurate memory leak information even with failing tests (memory leak info will still be inaccurate with failing tests on PUC Lua 5.1, since PUC Lua 5.1 os.exit bypasses lua_close).

Thanks to @vanc for the fix, see https://github.com/luvit/luv/issues/382#issuecomment-546032911