### PR TITLE
Stop bindings that use uv_buf_t coercing numbers to strings

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -466,12 +466,12 @@ static int luv_fs_write(lua_State* L) {
     bufs = luv_prep_bufs(L, 2, &count);
     buf.base = NULL;
   }
-  else if (lua_isstring(L, 2)) {
-    luv_check_buf(L, 2, &buf);
+  else if (luv_isstring_strict(L, 2)) {
+    luv_prep_buf(L, 2, &buf);
     count = 1;
   }
   else {
-    return luaL_argerror(L, 2, "data must be string or table of strings");
+    return luaL_argerror(L, 2, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, 2)));
   }
 
   offset = luaL_checkinteger(L, 3);

--- a/src/luv.h
+++ b/src/luv.h
@@ -126,6 +126,7 @@ LUALIB_API int luaopen_luv (lua_State *L);
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
 static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf);
+static void luv_prep_buf(lua_State *L, int idx, uv_buf_t *pbuf);
 static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
 
 /* from tcp.c */

--- a/src/util.c
+++ b/src/util.c
@@ -88,6 +88,10 @@ static void luv_check_callable(lua_State* L, int index) {
   luaL_argerror(L, index, msg);
 }
 
+static int luv_isstring_strict(lua_State* L, int index) {
+  return lua_type(L, index) == LUA_TSTRING;
+}
+
 #if LUV_UV_VERSION_GEQ(1, 10, 0)
 static int luv_translate_sys_error(lua_State* L) {
   int status = luaL_checkinteger(L, 1);

--- a/src/util.h
+++ b/src/util.h
@@ -44,6 +44,9 @@ static int luv_is_callable(lua_State* L, int index);
 
 // Check if the argument is callable and throw an error if it's not
 static void luv_check_callable(lua_State* L, int index);
+
+// lua_isstring checks for string or number, this checks specifically for string
+static int luv_isstring_strict(lua_State* L, int index);
 #endif
 
 #endif


### PR DESCRIPTION
When a number is coerced to a string, that string is temporary and could be garbage collected before the uv_buf_t is used, leading to use-after-free.

Part of #397, see https://github.com/luvit/luv/issues/397#issuecomment-546791557 for the reproduction test case.

Also improves the error messages a bit, they now look like this:
```
bad argument #2 to 'fs_write' (data must be string or table of strings, got number)
bad argument #2 to 'fs_write' (expected table of strings, found number in the table)
```

---

Note that this same pattern of use-after-free could also affect how we pass strings to `uv_buf_t`. From the Lua reference manual: 

> Because Lua has garbage collection, there is no guarantee that the pointer returned by lua_tolstring will be valid after the corresponding value is removed from the stack.

I haven't found a way to reproduce this with strings yet (the memory layout of the internal Lua string table makes it less likely I believe), but it's probably possible.