### PR TITLE
Handle uv_buf_t passed to write/send functions properly

### DIFF
--- a/src/lreq.c
+++ b/src/lreq.c
@@ -66,7 +66,13 @@ static void luv_fulfill_req(lua_State* L, luv_req_t* data, int nargs) {
 static void luv_cleanup_req(lua_State* L, luv_req_t* data) {
   luaL_unref(L, LUA_REGISTRYINDEX, data->req_ref);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callback_ref);
-  luaL_unref(L, LUA_REGISTRYINDEX, data->data_ref);
+  if (data->data_ref == LUV_REQ_MULTIREF) {
+    for (int i = 0; ((int*)(data->data))[i] != LUA_NOREF; i++) {
+      luaL_unref(L, LUA_REGISTRYINDEX, ((int*)(data->data))[i]);
+    }
+  }
+  else
+    luaL_unref(L, LUA_REGISTRYINDEX, data->data_ref);
   free(data->data);
   free(data);
 }

--- a/src/lreq.h
+++ b/src/lreq.h
@@ -27,6 +27,9 @@ typedef struct {
   void* data; /* extra data */
 } luv_req_t;
 
+// This is an arbitrary value that we can assume will never be returned by luaL_ref
+#define LUV_REQ_MULTIREF (-0x1234)
+
 #ifdef LUV_SOURCE
 /* Used in the top of a setup function to check the arg
    and ref the callback to an integer.

--- a/src/luv.h
+++ b/src/luv.h
@@ -128,7 +128,7 @@ static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* b
 
 /* From misc.c */
 static void luv_prep_buf(lua_State *L, int idx, uv_buf_t *pbuf);
-static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
+static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count, int **refs);
 static uv_buf_t* luv_check_bufs(lua_State* L, int index, size_t *count, luv_req_t* req_data);
 static uv_buf_t* luv_check_bufs_noref(lua_State* L, int index, size_t *count);
 

--- a/src/luv.h
+++ b/src/luv.h
@@ -125,8 +125,12 @@ LUALIB_API int luaopen_luv (lua_State *L);
 /* From stream.c */
 static uv_stream_t* luv_check_stream(lua_State* L, int index);
 static void luv_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);
-static void luv_check_buf(lua_State *L, int idx, uv_buf_t *pbuf);
+
+/* From misc.c */
+static void luv_prep_buf(lua_State *L, int idx, uv_buf_t *pbuf);
 static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count);
+static uv_buf_t* luv_check_bufs(lua_State* L, int index, size_t *count, luv_req_t* req_data);
+static uv_buf_t* luv_check_bufs_noref(lua_State* L, int index, size_t *count);
 
 /* from tcp.c */
 static void parse_sockaddr(lua_State* L, struct sockaddr_storage* address);

--- a/src/misc.c
+++ b/src/misc.c
@@ -104,7 +104,7 @@ static uv_buf_t* luv_check_bufs(lua_State* L, int index, size_t* count, luv_req_
     req_data->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   }
   else {
-    return luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
+    luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
   }
   return bufs;
 }
@@ -122,7 +122,7 @@ static uv_buf_t* luv_check_bufs_noref(lua_State* L, int index, size_t* count) {
     luv_prep_buf(L, index, bufs);
   }
   else {
-    return luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
+    luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
   }
   return bufs;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -42,6 +42,91 @@ static int luv_version_string(lua_State* L) {
  return 1;
 }
 
+// requires the value at idx to be a string or number
+static void luv_prep_buf(lua_State *L, int idx, uv_buf_t *pbuf) {
+  size_t len;
+  // note: if the value is a number, lua_tolstring converts the stack value to a string
+  pbuf->base = (char*)lua_tolstring(L, idx, &len);
+  pbuf->len = len;
+}
+
+// - number of buffers is stored in *count
+// - if refs is non-NULL, then *refs is set to a heap-allocated, LUA_NOREF-terminated array
+//   of ref integers (refs are to each string in the bufs)
+// returns: heap-allocated array of uv_buf_t
+static uv_buf_t* luv_prep_bufs(lua_State* L, int index, size_t *count, int **refs) {
+  uv_buf_t *bufs;
+  size_t i;
+  *count = lua_rawlen(L, index);
+  bufs = (uv_buf_t*)malloc(sizeof(uv_buf_t) * *count);
+  int *refs_array = NULL;
+  if (refs)
+    refs_array = (int*)malloc(sizeof(int) * (*count + 1));
+  for (i = 0; i < *count; ++i) {
+    lua_rawgeti(L, index, i + 1);
+    if (!lua_isstring(L, -1)) {
+      luaL_argerror(L, index, lua_pushfstring(L, "expected table of strings, found %s in the table", luaL_typename(L, -1)));
+      return NULL;
+    }
+    luv_prep_buf(L, -1, &bufs[i]);
+    if (refs) {
+      // push the string again to ref it, will be popped by luaL_ref
+      lua_pushvalue(L, -1);
+      refs_array[i] = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+    lua_pop(L, 1);
+  }
+  if (refs) {
+    // refs array is LUA_NOREF-terminated
+    refs_array[*count] = LUA_NOREF;
+    *refs = refs_array;
+  }
+  return bufs;
+}
+
+// Sets up a uv_bufs_t array to pass to write/send libuv functions that take a uv_buf_t*
+// - count: set to length of the returned uv_buf_t array
+// - req_data: refs to the strings used are stored in req_data->data/req_data->data_ref
+// returns: heap-allocated array of uv_buf_t
+static uv_buf_t* luv_check_bufs(lua_State* L, int index, size_t* count, luv_req_t* req_data) {
+  uv_buf_t* bufs = NULL;
+  if (lua_istable(L, index)) {
+    int* refs = NULL;
+    bufs = luv_prep_bufs(L, index, count, &refs);
+    req_data->data = refs;
+    req_data->data_ref = LUV_REQ_MULTIREF;
+  }
+  else if (lua_isstring(L, index)) {
+    *count = 1;
+    bufs = (uv_buf_t*)malloc(sizeof(uv_buf_t));
+    luv_prep_buf(L, index, bufs);
+    lua_pushvalue(L, index);
+    req_data->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+  }
+  else {
+    return luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
+  }
+  return bufs;
+}
+
+// Like luv_check_bufs but does not ref the buf strings.
+// Only meant to be used for functions like luv_udp_try_send.
+static uv_buf_t* luv_check_bufs_noref(lua_State* L, int index, size_t* count) {
+  uv_buf_t* bufs = NULL;
+  if (lua_istable(L, index)) {
+    bufs = luv_prep_bufs(L, index, count, NULL);
+  }
+  else if (lua_isstring(L, index)) {
+    *count = 1;
+    bufs = (uv_buf_t*)malloc(sizeof(uv_buf_t));
+    luv_prep_buf(L, index, bufs);
+  }
+  else {
+    return luaL_argerror(L, index, lua_pushfstring(L, "data must be string or table of strings, got %s", luaL_typename(L, index)));
+  }
+  return bufs;
+}
+
 static int luv_get_process_title(lua_State* L) {
   char title[MAX_TITLE_LENGTH];
   int ret = uv_get_process_title(title, MAX_TITLE_LENGTH);


### PR DESCRIPTION
Part of #397

luv_req_t now stores either one or multiple refs to the strings passed to functions that use uv_buf_t. This fixes those strings possibly being garbage collected between the time the uv_buf_t is constructed and the time the send/write actually completes. See https://github.com/luvit/luv/issues/397 for a more complete explanation of the problem.

- Introduces a constant called `LUV_REQ_MULTIREF` which is an arbitrary negative value that luaL_ref will never return that signifies that `luv_req_t.data` is a `LUA_NOREF`-terminated array of `int`s and handles that case accordingly in `luv_cleanup_req`. This might be more hacky than it needs to be but it makes it possible to leave the structure of `luv_req_t` unchanged.
- Maintains backwards compatibility in that it will still coerce numbers to strings (see https://github.com/luvit/luv/pull/426)
- Factored out and moved `uv_buf_t`-related functions to misc.c (matches where uv_buf_t is in Libuv: http://docs.libuv.org/en/v1.x/misc.html#c.uv_buf_t)
  + Has the side-benefit of bringing udp_send/udp_try_send in line with the other send/write functions in that it will now accept either a string or a table of strings (before the udp send functions only accepted a single string)