### PR TITLE
Fix Makefile passing build type too late and some other improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,14 @@ WITH_SHARED_LIBUV ?= OFF
 WITH_LUA_ENGINE ?= LuaJIT
 LUA_BUILD_TYPE ?= Static
 LUA_COMPAT53_DIR ?= deps/lua-compat-5.3
+BUILD_DIR ?= build
+# options: Release, Debug, RelWithDebInfo, MinSizeRel
+BUILD_TYPE ?= RelWithDebInfo
 
 ifeq ($(WITH_LUA_ENGINE), LuaJIT)
-  LUABIN=build/luajit
+  LUABIN=$(BUILD_DIR)/luajit
 else
-  LUABIN=build/lua
+  LUABIN=$(BUILD_DIR)/lua
 endif
 
 CMAKE_OPTIONS += \
@@ -23,7 +26,8 @@ CMAKE_OPTIONS += \
 	-DWITH_SHARED_LIBUV=$(WITH_SHARED_LIBUV) \
 	-DWITH_LUA_ENGINE=$(WITH_LUA_ENGINE) \
 	-DLUA_BUILD_TYPE=$(LUA_BUILD_TYPE) \
-	-DLUA_COMPAT53_DIR=$(LUA_COMPAT53_DIR)
+	-DLUA_COMPAT53_DIR=$(LUA_COMPAT53_DIR) \
+	-DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 
 ifeq ($(MAKE),mingw32-make)
 CMAKE_OPTIONS += -G"MinGW Makefiles"
@@ -45,18 +49,18 @@ deps/luajit/src:
 deps/lua-compat-5.3/c-api:
 	git submodule update --init deps/lua-compat-5.3
 
-build/Makefile: deps/libuv/include deps/luajit/src deps/lua-compat-5.3/c-api
-	cmake -H. -Bbuild ${CMAKE_OPTIONS}
+$(BUILD_DIR)/Makefile: deps/libuv/include deps/luajit/src deps/lua-compat-5.3/c-api
+	cmake -H. -B$(BUILD_DIR) ${CMAKE_OPTIONS}
 
-luv: build/Makefile
-	cmake --build build --config Debug
-	$(LUV_CP) build/luv$(LUV_EXT) luv$(LUV_EXT)
+luv: $(BUILD_DIR)/Makefile
+	cmake --build $(BUILD_DIR)
+	$(LUV_CP) $(BUILD_DIR)/luv$(LUV_EXT) luv$(LUV_EXT)
 
 install: luv
-	$(MAKE) -C build install
+	$(MAKE) -C $(BUILD_DIR) install
 
 clean:
-	rm -rf build luv.so
+	rm -rf $(BUILD_DIR) luv$(LUV_EXT)
 
 test: luv
 	${LUABIN} tests/run.lua


### PR DESCRIPTION
- Adds BUILD_DIR config option
- Adds BUILD_TYPE config option (i.e. Release, Debug, etc).
  + Default set to RelWithDebInfo.
  + Closes #425

---

Not sure what the default build type should be here. If anyone has any reasoning for choosing one over another, let me know.