### PR TITLE
Travis CI improvements (Valgrind/ASAN/etc)

### DIFF
--- a/.ci/bindcov.sh
+++ b/.ci/bindcov.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+unbound_functions=0
+skipped=()
+
+# false positives
+skipped+=(uv_thread_create uv_thread_create_ex)
+
+# intentionally not bound
+skipped+=(uv_replace_allocator)
+
+# threading/synchronization
+skipped+=(
+	uv_mutex_init uv_mutex_init_recursive uv_mutex_destroy uv_mutex_lock uv_mutex_trylock
+	uv_mutex_unlock uv_rwlock_init uv_rwlock_destroy uv_rwlock_rdlock uv_rwlock_tryrdlock 
+	uv_rwlock_rdunlock uv_rwlock_wrlock uv_rwlock_trywrlock uv_rwlock_wrunlock uv_sem_init
+	uv_sem_destroy uv_sem_post uv_sem_wait uv_sem_trywait uv_cond_init uv_cond_destroy
+	uv_cond_signal uv_cond_broadcast uv_barrier_init uv_barrier_destroy uv_barrier_wait
+	uv_cond_wait uv_cond_timedwait uv_once uv_key_create uv_key_delete uv_key_get uv_key_set
+)
+
+# yet to be implemented / ruled out
+# https://github.com/luvit/luv/issues/410
+skipped+=(
+	uv_loop_configure uv_setup_args uv_default_loop uv_loop_new uv_loop_delete
+	uv_loop_size uv_loop_fork uv_loop_get_data uv_loop_set_data uv_strerror uv_strerror_r uv_err_name
+	uv_err_name_r uv_handle_size uv_handle_get_type uv_handle_type_name uv_handle_get_data
+	uv_handle_get_loop uv_handle_set_data uv_req_size uv_req_get_data uv_req_set_data uv_req_get_type
+	uv_req_type_name uv_udp_set_source_membership uv_pipe_chmod uv_process_get_pid uv_get_osfhandle
+	uv_open_osfhandle uv_fs_get_type uv_fs_get_result uv_fs_get_ptr uv_fs_get_path uv_fs_get_statbuf
+	uv_ip4_addr uv_ip6_addr uv_ip4_name uv_ip6_name uv_inet_ntop uv_inet_pton uv_dlopen uv_dlclose
+	uv_dlsym uv_dlerror
+)
+
+# get all public uv_ functions from uv.h
+for fn in `grep -oP "UV_EXTERN [^\(]+ uv_[^\(]+\(" deps/libuv/include/uv.h | sed 's/($//' | grep -oP "[^ ]+$"`; do
+	# skip everything in the skipped array and any initialization/cleanup fns
+	if [[ " ${skipped[@]} " =~ " ${fn} " || $fn == *_init* || $fn == *_free* || $fn == *_cleanup ]] ; then
+		continue
+	fi
+	# count all uses
+	count=`grep -o "$fn" src/*.c | wc -l`
+	# check if a luv_ version exists
+	grep -Fq "l$fn" src/*.c
+	bound=$?
+	# not bound
+	if [ ! $bound -eq 0 ] ; then
+		# not used
+		if [ $count -eq 0 ] ; then
+			echo $fn
+		else
+			echo "$fn (used internally but not bound externally)"
+		fi
+		unbound_functions=$((unbound_functions+1))
+	fi
+done
+
+exit $unbound_functions

--- a/.ci/lsan_build.supp
+++ b/.ci/lsan_build.supp
@@ -1,0 +1,1 @@
+leak:buildvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
       script:
         - ./tests/test-sigchld-after-lua_close.sh
   include:
-    - stage: sanity checks
+    - stage: check
       name: clang-asan
       os: linux
       compiler: clang
@@ -97,6 +97,11 @@ jobs:
       after_deploy:
         - luarocks install lua-cjson # required for luarocks upload
         - luarocks upload luv-$TRAVIS_TAG.rockspec --api-key=$LUAROCKS_API_KEY --force
+
+stages:
+  - check
+  - test
+  - deploy
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
     - LUAROCKS=3.1.3 WITH_LUA_ENGINE=Lua LUA=lua5.3
     - LUAROCKS=3.1.3 WITH_LUA_ENGINE=LuaJIT LUA=luajit2.1
 
-    - PROCESS_CLEANUP_TEST=1 LUA=lua5.2
-
 os:
   - linux
   - osx
@@ -31,7 +29,7 @@ before_install:
   - source .ci/setenv_lua.sh
 
 script:
-  - if [ "x$PROCESS_CLEANUP_TEST" = "x" ]; then make && make test; else ./tests/test-sigchld-after-lua_close.sh; fi
+  - make && make test
   # Test rock installation
   - luarocks make
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
@@ -44,7 +42,38 @@ script:
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
 
 jobs:
+  fast_finish: true
+  allow_failures:
+    - name: process cleanup test
+      os: linux
+      env:
+        - WITH_LUA_ENGINE=Lua
+      script:
+        - ./tests/test-sigchld-after-lua_close.sh
   include:
+    - stage: sanity checks
+      name: clang-asan
+      os: linux
+      compiler: clang
+      env:
+        - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1"
+        - UBSAN_OPTIONS="print_stacktrace=1"
+        - BUILD_TYPE=Debug
+        - WITH_LUA_ENGINE=Lua
+      script:
+        - CMAKE_OPTIONS="-DCMAKE_C_FLAGS=-fsanitize=address,undefined" make && make test
+    - name: valgrind
+      os: linux
+      env:
+        - BUILD_TYPE=Debug
+        - WITH_LUA_ENGINE=Lua
+      script:
+        - make
+        - valgrind --error-exitcode=1 --leak-check=full ./build/lua tests/run.lua
+    - name: bindings coverage
+      os: linux
+      script:
+        - ./.ci/bindcov.sh
     - stage: deploy
       if: tag IS present
       env: WITH_LUA_ENGINE=LuaJIT LUA=luajit2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ os:
   - linux
   - osx
 
-before_install:
-  - git submodule update --init --recursive
-  - git submodule update --recursive
-
 script:
   - make && make test
   # Setup LuaRocks

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ jobs:
         - make
         - valgrind --error-exitcode=1 --leak-check=full ./build/lua tests/run.lua
     - name: bindings coverage
+      addons:
+        apt: # don't need cmake for this one
       os: linux
       script:
         - ./.ci/bindcov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ os:
 before_install:
   - git submodule update --init --recursive
   - git submodule update --recursive
-  - source .ci/setenv_lua.sh
 
 script:
   - make && make test
+  # Setup LuaRocks
+  - source .ci/setenv_lua.sh
   # Test rock installation
   - luarocks make
   - test $PWD = `lua -e "print(require'luv'.cwd())"`

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,9 @@ jobs:
       os: linux
       addons:
         apt:
+          sources:
+            # Need a more up-to-date Valgrind to dodge https://bugs.kde.org/show_bug.cgi?id=381289
+            - sourceline: 'ppa:msulikowski/valgrind'
           packages:
             - valgrind
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
 
 jobs:
-  #fast_finish: true
+  fast_finish: true
   include:
     - stage: check
       name: bindings coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         apt:
           sources:
             # Need a more up-to-date Valgrind to dodge https://bugs.kde.org/show_bug.cgi?id=381289
-            - sourceline: 'ppa:msulikowski/valgrind'
+            - sourceline: 'ppa:jonathonf/development-tools'
           packages:
             - valgrind
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - test $PWD = `lua -e "print(require'luv'.cwd())"`
 
 jobs:
-  fast_finish: true
+  #fast_finish: true
   include:
     - stage: check
       name: bindings coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ jobs:
         - CMAKE_OPTIONS="-DCMAKE_C_FLAGS=-fsanitize=address,undefined" make && make test
     - name: valgrind
       os: linux
+      addons:
+        apt:
+          packages:
+            - valgrind
       env:
         - BUILD_TYPE=Debug
         - WITH_LUA_ENGINE=Lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,15 @@ script:
 
 jobs:
   fast_finish: true
-  allow_failures:
-    - name: process cleanup test
-      os: linux
-      env:
-        - WITH_LUA_ENGINE=Lua
-      script:
-        - ./tests/test-sigchld-after-lua_close.sh
   include:
     - stage: check
-      name: clang-asan
+      name: bindings coverage
+      addons:
+        apt: # don't need cmake for this one
+      os: linux
+      script:
+        - ./.ci/bindcov.sh
+    - name: clang-asan
       os: linux
       compiler: clang
       env:
@@ -74,12 +73,13 @@ jobs:
       script:
         - make
         - valgrind --error-exitcode=1 --leak-check=full ./build/lua tests/run.lua
-    - name: bindings coverage
-      addons:
-        apt: # don't need cmake for this one
+    - name: process cleanup test
       os: linux
+      env:
+        - WITH_LUA_ENGINE=Lua
       script:
-        - ./.ci/bindcov.sh
+        - ./tests/test-sigchld-after-lua_close.sh
+
     - stage: deploy
       if: tag IS present
       env: WITH_LUA_ENGINE=LuaJIT LUA=luajit2.1

--- a/src/fs.c
+++ b/src/fs.c
@@ -479,7 +479,7 @@ static int luv_fs_write(lua_State* L) {
   req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
   req->ptr = buf.base;
-  //((luv_req_t*)req->data)->data = bufs;
+  ((luv_req_t*)req->data)->data = bufs;
   FS_CALL(write, req, file, bufs ? bufs : &buf, count, offset);
 }
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -479,7 +479,7 @@ static int luv_fs_write(lua_State* L) {
   req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
   req->ptr = buf.base;
-  ((luv_req_t*)req->data)->data = bufs;
+  //((luv_req_t*)req->data)->data = bufs;
   FS_CALL(write, req, file, bufs ? bufs : &buf, count, offset);
 }
 

--- a/tests/manual-test-leaks.lua
+++ b/tests/manual-test-leaks.lua
@@ -1,3 +1,7 @@
+-- this is a primitive test for leaks that has been
+-- superseded by running better leak checking tools
+-- like Valgrind and LSAN/ASAN
+
 return require('lib/tap')(function (test)
 
   local function bench(uv, p, count, fn)

--- a/tests/test-sigchld-after-lua_close.sh
+++ b/tests/test-sigchld-after-lua_close.sh
@@ -3,6 +3,8 @@
 # not done by "userspace".
 # Details: https://github.com/luvit/luv/issues/193
 
+set -eufxo pipefail
+
 # This test modifies one of the examples to skip libuv process cleanup,
 # purposely making it leave SIGCHLD signal handler.
 #

--- a/tests/test-sigchld-after-lua_close.sh
+++ b/tests/test-sigchld-after-lua_close.sh
@@ -3,7 +3,7 @@
 # not done by "userspace".
 # Details: https://github.com/luvit/luv/issues/193
 
-set -eufxo pipefail
+set -e
 
 # This test modifies one of the examples to skip libuv process cleanup,
 # purposely making it leave SIGCHLD signal handler.


### PR DESCRIPTION
Still a work-in-progress. Once finished, will close #395.

- [x] Adds a 'Check' stage to the CI that runs before the general 'Test' stage
- [x] Adds Valgrind check
  + [x] Need to intentionally introduce a leak/error to make sure Valgrind catches it (https://travis-ci.org/luvit/luv/builds/605741562)
- [x] Adds LSAN/ASAN/UBSAN check
  + [x] Need to intentionally introduce a leak/error to make sure LSAN/ASAN/UBSAN catches it (https://travis-ci.org/luvit/luv/builds/605741562)
- [x] Adds a "binding coverage" check script I mentioned [here](https://github.com/luvit/luv/issues/410#issuecomment-541479551) to catch any unbound functions when we update to new Libuv versions. Added the unbound functions in #410 as exceptions for now; they should be removed from the `$skipped` array as they are resolved.
- [x] `test-sigchld-after-lua_close.sh` is still 'passing' even though the Lua script is throwing an error. Once that's fixed, though, it will depend on https://github.com/luvit/luv/pull/414 in order to fix the Lua execution error (I still need to investigate https://github.com/luvit/luv/pull/414#issuecomment-542138369 more before I merge that). (EDIT: Fixed by #436)
- [x] Deprecated `test-leaks.lua` and moved it to `manual-test-leaks.lua` since Valgrind/ASAN is much better at detecting leaks. This has a side benefit of speeding up our test suite a bit.
- Also closes #428 and closes #429

---

EDIT: Note that right now the ASAN and Valgrind checks use PUC Lua 5.3. I did that because it's simpler to get working (see https://github.com/luvit/luv/issues/382#issuecomment-539765951) and any errors should be less cryptic, but it might be better to check against LuaJIT instead since that's what `luv` is used with most of the time.