### PR TITLE
Hard exit on pcall failed

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -583,11 +583,12 @@ LUALIB_API int luv_cfpcall(lua_State* L, int nargs, int nresult, int flags) {
     ret = -ret;
     break;
   case LUA_ERRRUN:
-  case LUA_ERRSYNTAX:
   case LUA_ERRERR:
   default:
     if ((flags & LUVF_CALLBACK_NOERRMSG) == 0)
       fprintf(stderr, "Uncaught Error: %s\n", lua_tostring(L, -1));
+    if ((flags & LUVF_CALLBACK_NOEXIT) == 0)
+      exit(-1);
     lua_pop(L, 1);
     ret = -ret;
     break;

--- a/src/work.c
+++ b/src/work.c
@@ -96,7 +96,7 @@ static void luv_work_cb(uv_work_t* req) {
 
   if (lua_isfunction(L, -1)) {
     int i = luv_thread_arg_push(L, &work->arg, 0);
-    i = luv_cfpcall(L, i, LUA_MULTRET, LUVF_CALLBACK_NOEXIT);
+    i = luv_cfpcall(L, i, LUA_MULTRET, 0);
     luv_thread_arg_clear(NULL, &work->arg, 0);
     if ( i>=0 ) {
       //clear in main threads, luv_after_work_cb


### PR DESCRIPTION
1. To avoid undefine…d behavior in libuv and luajit follow https://github.com/luvit/luv/commit/7526c1d9955f085df9eb1c25fcc31c0cfe67e583.
2. Replay https://github.com/luvit/luv/issues/433.
3. LUVF_CALLBACK_ flags introduced by https://github.com/luvit/luv/commit/5b68007d6919edd2f5c99830ba0679f958b1235c#diff-4221738e9478598ca8f06be66d888559