### PR TITLE
Fix an unitilized variable warning.

### DIFF
--- a/src/pipe.c
+++ b/src/pipe.c
@@ -24,7 +24,7 @@ static uv_pipe_t* luv_check_pipe(lua_State* L, int index) {
 
 static int luv_new_pipe(lua_State* L) {
   uv_pipe_t* handle;
-  int ipc, ret;
+  int ipc = 0 , ret;
   luv_ctx_t* ctx = luv_context(L);
   ipc = luv_optboolean(L, 1, 0);
   handle = (uv_pipe_t*)luv_newuserdata(L, sizeof(*handle));


### PR DESCRIPTION
Hi, I noticed a warning when compiling this on OpenBSD:

```
In file included from /home/pobj/libluv-1.32.0.0/luv-1.32.0-0/src/luv.c:41:
/home/pobj/libluv-1.32.0.0/luv-1.32.0-0/src/pipe.c:29:7: warning: variable 'ipc' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  if (lua_isboolean(L, 1)) {
      ^~~~~~~~~~~~~~~~~~~
/usr/local/include/lua-5.1/lua.h:268:28: note: expanded from macro 'lua_isboolean'
#define lua_isboolean(L,n)      (lua_type(L, (n)) == LUA_TBOOLEAN)
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/pobj/libluv-1.32.0.0/luv-1.32.0-0/src/pipe.c:35:41: note: uninitialized use occurs here
  ret = uv_pipe_init(ctx->loop, handle, ipc);
                                        ^~~
/home/pobj/libluv-1.32.0.0/luv-1.32.0-0/src/pipe.c:29:3: note: remove the 'if' if its condition is always true
  if (lua_isboolean(L, 1)) {
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/pobj/libluv-1.32.0.0/luv-1.32.0-0/src/pipe.c:27:10: note: initialize the variable 'ipc'
to silence this warning
  int ipc, ret;
         ^
          = 0
1 warning generated.
```

This PR should fix it.