### PR TITLE
Quick fix for PROCESS_CLEANUP_TEST CI failures

### DIFF
--- a/examples/talking-to-children.lua
+++ b/examples/talking-to-children.lua
@@ -24,7 +24,10 @@ local function onread(err, chunk)
   end
 end
 
-local function onshutdown()
+local function onshutdown(err)
+  if err == "ECANCELED" then
+    return
+  end
   uv.close(handle, onclose)
 end
 


### PR DESCRIPTION
The problem is that the shutdown callback is being called during loop_gc, so the Lua/Libuv state is being closed/free'd and the `handle` local var has already been closed/free'd so it's no longer a valid uv_stream_t (see https://github.com/luvit/luv/pull/414).

This will fix PROCESS_CLEANUP_TEST but there is more to do to solve the general case of 'things happening during loop gc'