### PR TITLE
travis: Fix Valgrind detecting false-positive leaks in child when uv_spawn fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
         - WITH_LUA_ENGINE=Lua
       script:
         - make
-        - valgrind --error-exitcode=1 --leak-check=full ./build/lua tests/run.lua
+        - valgrind --error-exitcode=1 --leak-check=full --child-silent-after-fork=yes ./build/lua tests/run.lua
     - name: process cleanup test
       os: linux
       env:


### PR DESCRIPTION
Fixes https://github.com/luvit/luv/issues/382#issuecomment-549249061, see https://github.com/libuv/libuv/issues/727