### PR TITLE
travis: Default MACOSX_DEPLOYMENT_TARGET to 10.4 for LuaJIT 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
 env:
   global:
     - LUAROCKS=2.3.0
+    # For LuaJIT 2.1, see https://github.com/LuaJIT/LuaJIT/commit/8961a92dd1607108760694af3486b4434602f8be
+    - MACOSX_DEPLOYMENT_TARGET=10.4
   matrix:
     - WITH_LUA_ENGINE=Lua LUA=lua5.3
     - WITH_LUA_ENGINE=LuaJIT LUA=luajit2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - LUAROCKS=2.3.0
     # For LuaJIT 2.1, see https://github.com/LuaJIT/LuaJIT/commit/8961a92dd1607108760694af3486b4434602f8be
-    - MACOSX_DEPLOYMENT_TARGET=10.4
+    - MACOSX_DEPLOYMENT_TARGET=10.12
   matrix:
     - WITH_LUA_ENGINE=Lua LUA=lua5.3
     - WITH_LUA_ENGINE=LuaJIT LUA=luajit2.1


### PR DESCRIPTION
This fixes the issue described in #446 but the CI is still failing due to

```
lj_err.c:290:8: error: thread-local storage is not supported for the current target
static __thread _Unwind_Exception static_uex;
       ^
```

caused by https://github.com/LuaJIT/LuaJIT/commit/44382e833a9334c19e47e64e8078a322026e094d

Not sure how to fix that. Need someone more familiar with OSX to look into it. @zhaozg ?