### PR TITLE
src/lreq.c: fix build with gcc 4.8

### DIFF
--- a/src/lreq.c
+++ b/src/lreq.c
@@ -64,10 +64,11 @@ static void luv_fulfill_req(lua_State* L, luv_req_t* data, int nargs) {
 }
 
 static void luv_cleanup_req(lua_State* L, luv_req_t* data) {
+  int i;
   luaL_unref(L, LUA_REGISTRYINDEX, data->req_ref);
   luaL_unref(L, LUA_REGISTRYINDEX, data->callback_ref);
   if (data->data_ref == LUV_REQ_MULTIREF) {
-    for (int i = 0; ((int*)(data->data))[i] != LUA_NOREF; i++) {
+    for (i = 0; ((int*)(data->data))[i] != LUA_NOREF; i++) {
       luaL_unref(L, LUA_REGISTRYINDEX, ((int*)(data->data))[i]);
     }
   }


### PR DESCRIPTION
Since commit 3e34390cc15101d7fc46ea26f5adf9ac022c2029, build fails with gcc 4.8.3 on:

```
In file included from /usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output/build/luv-1.34.1-1/src/luv.c:27:0:
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output/build/luv-1.34.1-1/src/lreq.c: In function 'luv_cleanup_req':
/usr/lfs/hdd_v1/rc-buildroot-test/scripts/instance-0/output/build/luv-1.34.1-1/src/lreq.c:70:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int i = 0; ((int*)(data->data))[i] != LUA_NOREF; i++) {
     ^
```
Fixes:
 - http://autobuild.buildroot.org/results/83b34e606b128546da8a70836d039090e334a1ec

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>