### PR TITLE
Make Luv work with Libuv versions all the way back to 1.0.0

### DIFF
--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -169,5 +169,19 @@ function utils.prettyPrint(...)
   print(table.concat(arguments, "\t"))
 end
 
+function utils.uvVersionGEQ(min_version)
+  if not min_version then return true end
+  local min_version_num = min_version
+  if type(min_version) == "string" then
+    local version_parts = {}
+    for part in min_version:gmatch("%d+") do
+      table.insert(version_parts, tonumber(part))
+    end
+    assert(#version_parts == 3, "malformed version string: " .. min_version)
+    min_version_num = version_parts[1]*0x10000 + version_parts[2]*0x100 + version_parts[3]
+  end
+  return uv.version() >= min_version_num
+end
+
 return utils
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -290,6 +290,12 @@ static int luv_getnameinfo(lua_State* L) {
   lua_pop(L, 1);
 
   ref = luv_check_continuation(L, 2);
+#if !LUV_UV_VERSION_GEQ(1, 3, 0)
+  // in libuv < 1.3.0, the callback cannot be NULL
+  if (ref == LUA_NOREF) {
+    return luaL_argerror(L, 2, "callback must be provided");
+  }
+#endif
 
   req = (uv_getnameinfo_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);

--- a/src/dns.c
+++ b/src/dns.c
@@ -188,6 +188,12 @@ static int luv_getaddrinfo(lua_State* L) {
   }
 
   ref = luv_check_continuation(L, 4);
+#if !LUV_UV_VERSION_GEQ(1, 3, 0)
+  // in libuv < 1.3.0, the callback cannot be NULL
+  if (ref == LUA_NOREF) {
+    return luaL_argerror(L, 4, "callback must be provided");
+  }
+#endif
   req = (uv_getaddrinfo_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
 
@@ -197,13 +203,14 @@ static int luv_getaddrinfo(lua_State* L) {
     lua_pop(L, 1);
     return luv_error(L, ret);
   }
+#if LUV_UV_VERSION_GEQ(1, 3, 0)
   if (ref == LUA_NOREF) {
-
     lua_pop(L, 1);
     luv_pushaddrinfo(L, req->addrinfo);
     uv_freeaddrinfo(req->addrinfo);
     luv_cleanup_req(L, (luv_req_t*)req->data);
   }
+#endif
   return 1;
 }
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -284,7 +284,9 @@ static int push_fs_result(lua_State* L, uv_fs_t* req) {
 #endif
 
     case UV_FS_READLINK:
+#if LUV_UV_VERSION_GEQ(1, 8, 0)
     case UV_FS_REALPATH:
+#endif
       lua_pushstring(L, (char*)req->ptr);
       return 1;
 
@@ -716,6 +718,7 @@ static int luv_fs_readlink(lua_State* L) {
   FS_CALL(readlink, req, path);
 }
 
+#if LUV_UV_VERSION_GEQ(1, 8, 0)
 static int luv_fs_realpath(lua_State* L) {
   luv_ctx_t* ctx = luv_context(L);
   const char* path = luaL_checkstring(L, 1);
@@ -724,6 +727,7 @@ static int luv_fs_realpath(lua_State* L) {
   req->data = luv_setup_req(L, ctx, ref);
   FS_CALL(realpath, req, path);
 }
+#endif
 
 static int luv_fs_chown(lua_State* L) {
   luv_ctx_t* ctx = luv_context(L);

--- a/src/fs.c
+++ b/src/fs.c
@@ -249,7 +249,9 @@ static int push_fs_result(lua_State* L, uv_fs_t* req) {
 #endif
     case UV_FS_UTIME:
     case UV_FS_FUTIME:
+#if LUV_UV_VERSION_GEQ(1, 14, 0)
     case UV_FS_COPYFILE:
+#endif
       lua_pushboolean(L, 1);
       return 1;
 

--- a/src/luv.c
+++ b/src/luv.c
@@ -298,8 +298,10 @@ static const luaL_Reg luv_functions[] = {
   {"version", luv_version},
   {"version_string", luv_version_string},
 #ifndef _WIN32
+#if LUV_UV_VERSION_GEQ(1, 8, 0)
   {"print_all_handles", luv_print_all_handles},
   {"print_active_handles", luv_print_active_handles},
+#endif
 #endif
 #if LUV_UV_VERSION_GEQ(1, 12, 0)
   {"os_getenv", luv_os_getenv},

--- a/src/luv.c
+++ b/src/luv.c
@@ -266,9 +266,11 @@ static const luaL_Reg luv_functions[] = {
 
   // misc.c
   {"chdir", luv_chdir},
+#if LUV_UV_VERSION_GEQ(1, 9, 0)
   {"os_homedir", luv_os_homedir},
   {"os_tmpdir", luv_os_tmpdir},
   {"os_get_passwd", luv_os_get_passwd},
+#endif
   {"cpu_info", luv_cpu_info},
   {"cwd", luv_cwd},
   {"exepath", luv_exepath},

--- a/src/luv.c
+++ b/src/luv.c
@@ -240,7 +240,9 @@ static const luaL_Reg luv_functions[] = {
   {"fs_link", luv_fs_link},
   {"fs_symlink", luv_fs_symlink},
   {"fs_readlink", luv_fs_readlink},
+#if LUV_UV_VERSION_GEQ(1, 8, 0)
   {"fs_realpath", luv_fs_realpath},
+#endif
   {"fs_chown", luv_fs_chown},
   {"fs_fchown", luv_fs_fchown},
 #if LUV_UV_VERSION_GEQ(1, 21, 0)

--- a/src/luv.c
+++ b/src/luv.c
@@ -159,7 +159,9 @@ static const luaL_Reg luv_functions[] = {
   {"pipe_bind", luv_pipe_bind},
   {"pipe_connect", luv_pipe_connect},
   {"pipe_getsockname", luv_pipe_getsockname},
+#if LUV_UV_VERSION_GEQ(1, 3, 0)
   {"pipe_getpeername", luv_pipe_getpeername},
+#endif
   {"pipe_pending_instances", luv_pipe_pending_instances},
   {"pipe_pending_count", luv_pipe_pending_count},
   {"pipe_pending_type", luv_pipe_pending_type},
@@ -413,7 +415,9 @@ static const luaL_Reg luv_pipe_methods[] = {
   {"bind", luv_pipe_bind},
   {"connect", luv_pipe_connect},
   {"getsockname", luv_pipe_getsockname},
+#if LUV_UV_VERSION_GEQ(1, 3, 0)
   {"getpeername", luv_pipe_getpeername},
+#endif
   {"pending_instances", luv_pipe_pending_instances},
   {"pending_count", luv_pipe_pending_count},
   {"pending_type", luv_pipe_pending_type},

--- a/src/misc.c
+++ b/src/misc.c
@@ -442,6 +442,7 @@ static int luv_setgid(lua_State* L){
   return 0;
 }
 
+#if LUV_UV_VERSION_GEQ(1, 8, 0)
 static int luv_print_all_handles(lua_State* L){
   luv_ctx_t* ctx = luv_context(L);
   uv_print_all_handles(ctx->loop, stderr);
@@ -453,6 +454,7 @@ static int luv_print_active_handles(lua_State* L){
   uv_print_active_handles(ctx->loop, stderr);
   return 0;
 }
+#endif
 #endif
 
 #if LUV_UV_VERSION_GEQ(1, 12, 0)

--- a/src/misc.c
+++ b/src/misc.c
@@ -334,6 +334,7 @@ static int luv_chdir(lua_State* L) {
   return luv_result(L, ret);
 }
 
+#if LUV_UV_VERSION_GEQ(1, 9, 0)
 static int luv_os_tmpdir(lua_State* L) {
   size_t size = 2*PATH_MAX;
   char tmpdir[2*PATH_MAX];
@@ -380,6 +381,7 @@ static int luv_os_get_passwd(lua_State* L) {
   uv_os_free_passwd(&pwd);
   return 1;
 }
+#endif
 
 #if LUV_UV_VERSION_GEQ(1, 29, 0)
 static int luv_get_constrained_memory(lua_State* L) {

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -72,6 +72,7 @@ static int luv_pipe_getsockname(lua_State* L) {
   return 1;
 }
 
+#if LUV_UV_VERSION_GEQ(1, 3, 0)
 static int luv_pipe_getpeername(lua_State* L) {
   uv_pipe_t* handle = luv_check_pipe(L, 1);
   size_t len = 2*PATH_MAX;
@@ -81,6 +82,7 @@ static int luv_pipe_getpeername(lua_State* L) {
   lua_pushlstring(L, buf, len);
   return 1;
 }
+#endif
 
 static int luv_pipe_pending_instances(lua_State* L) {
   uv_pipe_t* handle = luv_check_pipe(L, 1);

--- a/src/poll.c
+++ b/src/poll.c
@@ -48,10 +48,15 @@ static int luv_new_socket_poll(lua_State* L) {
   return 1;
 }
 
-// These are the same order as uv_run_mode which also starts at 0
 static const char *const luv_pollevents[] = {
-  "r", "w", "rw", "d", "rd", "wd", "rwd",
-  "p", "rp", "wp", "rwp", "dp", "rdp", "wdp", "rwdp", NULL
+  "r", "w", "rw",
+#if LUV_UV_VERSION_GEQ(1, 9, 0)
+  "d", "rd", "wd", "rwd",
+#endif
+#if LUV_UV_VERSION_GEQ(1, 14, 0)
+  "p", "rp", "wp", "rwp", "dp", "rdp", "wdp", "rwdp",
+#endif
+  NULL
 };
 
 static void luv_poll_cb(uv_poll_t* handle, int status, int events) {
@@ -71,10 +76,13 @@ static void luv_poll_cb(uv_poll_t* handle, int status, int events) {
     case UV_READABLE: evtstr = "r"; break;
     case UV_WRITABLE: evtstr = "w"; break;
     case UV_READABLE|UV_WRITABLE: evtstr = "rw"; break;
+#if LUV_UV_VERSION_GEQ(1, 9, 0)
     case UV_DISCONNECT: evtstr = "d"; break;
     case UV_READABLE|UV_DISCONNECT: evtstr = "rd"; break;
     case UV_WRITABLE|UV_DISCONNECT: evtstr = "wd"; break;
     case UV_READABLE|UV_WRITABLE|UV_DISCONNECT: evtstr = "rwd"; break;
+#endif
+#if LUV_UV_VERSION_GEQ(1, 14, 0)
     case UV_PRIORITIZED: evtstr = "p"; break;
     case UV_READABLE|UV_PRIORITIZED: evtstr = "rp"; break;
     case UV_WRITABLE|UV_PRIORITIZED: evtstr = "wp"; break;
@@ -83,6 +91,7 @@ static void luv_poll_cb(uv_poll_t* handle, int status, int events) {
     case UV_READABLE|UV_DISCONNECT|UV_PRIORITIZED: evtstr = "rdp"; break;
     case UV_WRITABLE|UV_DISCONNECT|UV_PRIORITIZED: evtstr = "wdp"; break;
     case UV_READABLE|UV_WRITABLE|UV_DISCONNECT|UV_PRIORITIZED: evtstr = "rwdp"; break;
+#endif
     default: evtstr = ""; break;
   }
   lua_pushstring(L, evtstr);
@@ -97,10 +106,13 @@ static int luv_poll_start(lua_State* L) {
     case 0: events = UV_READABLE; break;
     case 1: events = UV_WRITABLE; break;
     case 2: events = UV_READABLE | UV_WRITABLE; break;
+#if LUV_UV_VERSION_GEQ(1, 9, 0)
     case 3: events = UV_DISCONNECT; break;
     case 4: events = UV_READABLE|UV_DISCONNECT; break;
     case 5: events = UV_WRITABLE|UV_DISCONNECT; break;
     case 6: events = UV_READABLE|UV_WRITABLE|UV_DISCONNECT; break;
+#endif
+#if LUV_UV_VERSION_GEQ(1, 14, 0)
     case 7: events = UV_PRIORITIZED; break;
     case 8: events = UV_READABLE|UV_PRIORITIZED; break;
     case 9: events = UV_WRITABLE|UV_PRIORITIZED; break;
@@ -109,6 +121,7 @@ static int luv_poll_start(lua_State* L) {
     case 12: events = UV_READABLE|UV_DISCONNECT|UV_PRIORITIZED; break;
     case 13: events = UV_WRITABLE|UV_DISCONNECT|UV_PRIORITIZED; break;
     case 14: events = UV_READABLE|UV_WRITABLE|UV_DISCONNECT|UV_PRIORITIZED; break;
+#endif
     default: events = 0; /* unreachable */
   }
   luv_check_callback(L, (luv_handle_t*)handle->data, LUV_POLL, 3);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -28,6 +28,7 @@ static int luv_new_tcp(lua_State* L) {
   luv_ctx_t* ctx = luv_context(L);
   lua_settop(L, 1);
   handle = (uv_tcp_t*)luv_newuserdata(L, sizeof(*handle));
+#if LUV_UV_VERSION_GEQ(1, 7, 0)
   if (lua_isnoneornil(L, 1)) {
     ret = uv_tcp_init(ctx->loop, handle);
   }
@@ -48,6 +49,9 @@ static int luv_new_tcp(lua_State* L) {
     }
     ret = uv_tcp_init_ex(ctx->loop, handle, flags);
   }
+#else
+  ret = uv_tcp_init(ctx->loop, handle);
+#endif
   if (ret < 0) {
     lua_pop(L, 1);
     return luv_error(L, ret);

--- a/src/udp.c
+++ b/src/udp.c
@@ -325,8 +325,11 @@ static int luv_udp_recv_start(lua_State* L) {
   luv_check_callback(L, (luv_handle_t*)handle->data, LUV_RECV, 2);
   ret = uv_udp_recv_start(handle, luv_alloc_cb, luv_udp_recv_cb);
 #if LUV_UV_VERSION_LEQ(1, 23, 0)
+#if LUV_UV_VERSION_GEQ(1, 10, 0)
   // in Libuv <= 1.23.0, uv_udp_recv_start will return untranslated error codes on Windows
+  // (uv_translate_sys_error was only made public in libuv >= 1.10.0)
   ret = uv_translate_sys_error(ret);
+#endif
 #endif
   return luv_result(L, ret);
 }

--- a/src/udp.c
+++ b/src/udp.c
@@ -27,6 +27,7 @@ static int luv_new_udp(lua_State* L) {
   lua_settop(L, 1);
   uv_udp_t* handle = (uv_udp_t*)luv_newuserdata(L, sizeof(*handle));
   int ret;
+#if LUV_UV_VERSION_GEQ(1, 7, 0)
   if (lua_isnoneornil(L, 1)) {
     ret = uv_udp_init(ctx->loop, handle);
   }
@@ -47,6 +48,9 @@ static int luv_new_udp(lua_State* L) {
     }
     ret = uv_udp_init_ex(ctx->loop, handle, flags);
   }
+#else
+  ret = uv_udp_init(ctx->loop, handle);
+#endif
   if (ret < 0) {
     lua_pop(L, 1);
     return luv_error(L, ret);

--- a/tests/test-callbacks.lua
+++ b/tests/test-callbacks.lua
@@ -38,18 +38,22 @@ return require('lib/tap')(function (test)
   end)
 
   test("luv_req_t: function", function (print, p, expect, uv)
-    local fn = function(err, path)
-      p(err, path)
+    local fn = function(err, stat)
+      assert(not err)
+      assert(stat)
     end
-    assert(uv.fs_realpath('.', expect(fn)))
+    assert(uv.fs_stat('.', expect(fn)))
   end)
 
   test("luv_req_t: callable table", function (print, p, expect, uv)
-    local fn = function(self, err, path)
-      p(self, err, path)
+    local callable
+    local fn = function(self, err, stat)
+      assert(self == callable)
+      assert(not err, err)
+      assert(stat)
     end
-    local callable = setmetatable({}, {__call=expect(fn)})
-    assert(uv.fs_realpath('.', callable))
+    callable = setmetatable({}, {__call=expect(fn)})
+    assert(uv.fs_stat('.', callable))
   end)
 
 end)

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -23,11 +23,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("Get all local http addresses sync", function (print, p, expect, uv)
-    local version = 0x10000 + 3*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.3.0")
-      return
-    end
     local res, errstr, err = uv.getaddrinfo(nil, "http")
     if errorAllowed(err) then
       print(err, "skipping")
@@ -36,7 +31,7 @@ return require('lib/tap')(function (test)
     assert(res, errstr)
     p(res, #res)
     assert(res[1].port == 80)
-  end)
+  end, "1.3.0")
 
   test("Get only ipv4 tcp adresses for luvit.io", function (print, p, expect, uv)
     assert(uv.getaddrinfo("luvit.io", nil, {
@@ -113,11 +108,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("Lookup local ipv4 address sync", function (print, p, expect, uv)
-    local version = 0x10000 + 3*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.3.0")
-      return
-    end
     local hostname, service, err = uv.getnameinfo({
       family = "inet",
     })
@@ -128,7 +118,7 @@ return require('lib/tap')(function (test)
     p{hostname=hostname,service=service}
     assert(hostname)
     assert(service)
-  end)
+  end, "1.3.0")
 
   test("Lookup local 127.0.0.1 ipv4 address", function (print, p, expect, uv)
     assert(uv.getnameinfo({

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -113,6 +113,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("Lookup local ipv4 address sync", function (print, p, expect, uv)
+    local version = 0x10000 + 3*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.3.0")
+      return
+    end
     local hostname, service, err = uv.getnameinfo({
       family = "inet",
     })

--- a/tests/test-dns.lua
+++ b/tests/test-dns.lua
@@ -23,6 +23,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("Get all local http addresses sync", function (print, p, expect, uv)
+    local version = 0x10000 + 3*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.3.0")
+      return
+    end
     local res, errstr, err = uv.getaddrinfo(nil, "http")
     if errorAllowed(err) then
       print(err, "skipping")

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -104,6 +104,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.realpath", function (print, p, expect, uv)
+    local version = 0x10000 + 8*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.8.0")
+      return
+    end
     p(assert(uv.fs_realpath('.')))
     assert(uv.fs_realpath('.', expect(function (err, path)
       assert(not err, err)
@@ -112,6 +117,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.copyfile", function (print, p, expect, uv)
+    local version = 0x10000 + 14*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.14.0")
+      return
+    end
     local path = "_test_"
     local path2 = "_test2_"
     local fd = assert(uv.fs_open(path, "w", 438))
@@ -218,12 +228,22 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.statfs sync", function (print, p, expect, uv)
+    local version = 0x10000 + 31*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.31.0")
+      return
+    end
     local stat = assert(uv.fs_statfs("."))
     p(stat)
     assert(stat.bavail>0)
   end)
 
   test("fs.statfs async", function (print, p, expect, uv)
+    local version = 0x10000 + 31*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.31.0")
+      return
+    end
     assert(uv.fs_statfs(".", expect(function (err, stat)
       assert(not err, err)
       p(stat)
@@ -232,6 +252,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.statfs sync error", function (print, p, expect, uv)
+    local version = 0x10000 + 31*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.31.0")
+      return
+    end
     local stat, err, code = uv.fs_statfs("BAD_FILE!")
     p{err=err,code=code,stat=stat}
     assert(not stat)
@@ -240,6 +265,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.statfs async error", function (print, p, expect, uv)
+    local version = 0x10000 + 31*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.31.0")
+      return
+    end
     assert(uv.fs_statfs("BAD_FILE@", expect(function (err, stat)
       p{err=err,stat=stat}
       assert(err)
@@ -292,6 +322,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.mkstemp async", function(print, p, expect, uv)
+    local version = 0x10000 + 34*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.34.0")
+      return
+    end
     local tp = "luvXXXXXX"
     uv.fs_mkstemp(tp, function(err, fd, path)
       assert(not err)
@@ -303,6 +338,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.mkstemp sync", function(print, p, expect, uv)
+    local version = 0x10000 + 34*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.34.0")
+      return
+    end
     local tp = "luvXXXXXX"
     local content = "hello world!"
     local fd, path = uv.fs_mkstemp(tp)
@@ -321,6 +361,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.mkstemp async error", function(print, p, expect, uv)
+    local version = 0x10000 + 34*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.34.0")
+      return
+    end
     local tp = "luvXXXXXZ"
     uv.fs_mkstemp(tp, function(err, path, fd)
       assert(err:match("^EINVAL:"))
@@ -330,6 +375,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.mkstemp sync error", function(print, p, expect, uv)
+    local version = 0x10000 + 34*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.34.0")
+      return
+    end
     local tp = "luvXXXXXZ"
     local path, err, code = uv.fs_mkstemp(tp)
     assert(path==nil)

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -104,24 +104,14 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.realpath", function (print, p, expect, uv)
-    local version = 0x10000 + 8*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.8.0")
-      return
-    end
     p(assert(uv.fs_realpath('.')))
     assert(uv.fs_realpath('.', expect(function (err, path)
       assert(not err, err)
       p(path)
     end)))
-  end)
+  end, "1.8.0")
 
   test("fs.copyfile", function (print, p, expect, uv)
-    local version = 0x10000 + 14*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.14.0")
-      return
-    end
     local path = "_test_"
     local path2 = "_test2_"
     local fd = assert(uv.fs_open(path, "w", 438))
@@ -130,152 +120,105 @@ return require('lib/tap')(function (test)
     assert(uv.fs_copyfile(path, path2))
     assert(uv.fs_unlink(path))
     assert(uv.fs_unlink(path2))
-  end)
+  end, "1.14.0")
 
   test("fs.{open,read,close}dir object sync #1", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-      local dir = assert(uv.fs_opendir('.'))
-      repeat
-        local dirent = dir:readdir()
-        if dirent then
-          assert(#dirent==1)
-          p(dirent)
-        end
-      until not dirent
-      assert(dir:closedir()==true)
-    else
-      print("skipped")
-    end
-  end)
+    local dir = assert(uv.fs_opendir('.'))
+    repeat
+      local dirent = dir:readdir()
+      if dirent then
+        assert(#dirent==1)
+        p(dirent)
+      end
+    until not dirent
+    assert(dir:closedir()==true)
+  end, "1.28.0")
 
   test("fs.{open,read,close}dir object sync #2", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-      local dir = assert(uv.fs_opendir('.'))
-      repeat
-        local dirent = dir:readdir()
-        if dirent then
-          assert(#dirent==1)
-          p(dirent)
-        end
-      until not dirent
-      dir:closedir(function(err, state)
-        assert(err==nil)
-        assert(state==true)
-        assert(tostring(dir):match("^uv_dir_t"))
-        print(dir, 'closed')
-      end)
-    else
-      print("skipped")
-    end
-  end)
+    local dir = assert(uv.fs_opendir('.'))
+    repeat
+      local dirent = dir:readdir()
+      if dirent then
+        assert(#dirent==1)
+        p(dirent)
+      end
+    until not dirent
+    dir:closedir(function(err, state)
+      assert(err==nil)
+      assert(state==true)
+      assert(tostring(dir):match("^uv_dir_t"))
+      print(dir, 'closed')
+    end)
+  end, "1.28.0")
 
   test("fs.{open,read,close}dir sync one entry", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-      local dir = assert(uv.fs_opendir('.'))
-      repeat
-        local dirent = uv.fs_readdir(dir)
-        if dirent then
-          assert(#dirent==1)
-          p(dirent)
-        end
-      until not dirent
-      assert(uv.fs_closedir(dir)==true)
-    else
-      print("skipped")
-    end
-  end)
+    local dir = assert(uv.fs_opendir('.'))
+    repeat
+      local dirent = uv.fs_readdir(dir)
+      if dirent then
+        assert(#dirent==1)
+        p(dirent)
+      end
+    until not dirent
+    assert(uv.fs_closedir(dir)==true)
+  end, "1.28.0")
 
   test("fs.{open,read,close}dir sync more entry", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-      local dir = assert(uv.fs_opendir('.', nil, 50))
-      repeat
-        local dirent = uv.fs_readdir(dir)
-        if dirent then p(dirent) end
-      until not dirent
-      assert(uv.fs_closedir(dir)==true)
-    else
-      print("skipped")
-    end
-  end)
+    local dir = assert(uv.fs_opendir('.', nil, 50))
+    repeat
+      local dirent = uv.fs_readdir(dir)
+      if dirent then p(dirent) end
+    until not dirent
+    assert(uv.fs_closedir(dir)==true)
+  end, "1.28.0")
 
   test("fs.{open,read,close}dir with more entry", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-
-      local function opendir_cb(err, dir)
+    local function opendir_cb(err, dir)
+      assert(not err)
+      local function readdir_cb(err, dirs)
         assert(not err)
-        local function readdir_cb(err, dirs)
-          assert(not err)
-          if dirs then
-            p(dirs)
-            uv.fs_readdir(dir, readdir_cb)
-          else
-            assert(uv.fs_closedir(dir)==true)
-          end
+        if dirs then
+          p(dirs)
+          uv.fs_readdir(dir, readdir_cb)
+        else
+          assert(uv.fs_closedir(dir)==true)
         end
-
-        uv.fs_readdir(dir, readdir_cb)
       end
 
-      assert(uv.fs_opendir('.', opendir_cb, 50))
-    else
-      print("skipped")
+      uv.fs_readdir(dir, readdir_cb)
     end
-  end)
+    assert(uv.fs_opendir('.', opendir_cb, 50))
+  end, "1.28.0")
 
   test("fs.statfs sync", function (print, p, expect, uv)
-    local version = 0x10000 + 31*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.31.0")
-      return
-    end
     local stat = assert(uv.fs_statfs("."))
     p(stat)
     assert(stat.bavail>0)
-  end)
+  end, "1.31.0")
 
   test("fs.statfs async", function (print, p, expect, uv)
-    local version = 0x10000 + 31*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.31.0")
-      return
-    end
     assert(uv.fs_statfs(".", expect(function (err, stat)
       assert(not err, err)
       p(stat)
       assert(stat.bavail>0)
     end)))
-  end)
+  end, "1.31.0")
 
   test("fs.statfs sync error", function (print, p, expect, uv)
-    local version = 0x10000 + 31*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.31.0")
-      return
-    end
     local stat, err, code = uv.fs_statfs("BAD_FILE!")
     p{err=err,code=code,stat=stat}
     assert(not stat)
     assert(err)
     assert(code == "ENOENT")
-  end)
+  end, "1.31.0")
 
   test("fs.statfs async error", function (print, p, expect, uv)
-    local version = 0x10000 + 31*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.31.0")
-      return
-    end
     assert(uv.fs_statfs("BAD_FILE@", expect(function (err, stat)
       p{err=err,stat=stat}
       assert(err)
       assert(not stat)
     end)))
-  end)
+  end, "1.31.0")
 
   test("fs.mkdtemp async", function(print, p, expect, uv)
     local tp = "luvXXXXXX"
@@ -322,11 +265,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("fs.mkstemp async", function(print, p, expect, uv)
-    local version = 0x10000 + 34*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.34.0")
-      return
-    end
     local tp = "luvXXXXXX"
     uv.fs_mkstemp(tp, function(err, fd, path)
       assert(not err)
@@ -335,14 +273,9 @@ return require('lib/tap')(function (test)
       assert(uv.fs_close(fd))
       assert(uv.fs_unlink(path))
     end)
-  end)
+  end, "1.34.0")
 
   test("fs.mkstemp sync", function(print, p, expect, uv)
-    local version = 0x10000 + 34*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.34.0")
-      return
-    end
     local tp = "luvXXXXXX"
     local content = "hello world!"
     local fd, path = uv.fs_mkstemp(tp)
@@ -358,32 +291,22 @@ return require('lib/tap')(function (test)
     assert(chunk==content)
     assert(uv.fs_close(fd))
     assert(uv.fs_unlink(path))
-  end)
+  end, "1.34.0")
 
   test("fs.mkstemp async error", function(print, p, expect, uv)
-    local version = 0x10000 + 34*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.34.0")
-      return
-    end
     local tp = "luvXXXXXZ"
     uv.fs_mkstemp(tp, function(err, path, fd)
       assert(err:match("^EINVAL:"))
       assert(path==nil)
       assert(fd==nil)
     end)
-  end)
+  end, "1.34.0")
 
   test("fs.mkstemp sync error", function(print, p, expect, uv)
-    local version = 0x10000 + 34*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.34.0")
-      return
-    end
     local tp = "luvXXXXXZ"
     local path, err, code = uv.fs_mkstemp(tp)
     assert(path==nil)
     assert(err:match("^EINVAL:"))
     assert(code=='EINVAL')
-  end)
+  end, "1.34.0")
 end)

--- a/tests/test-misc.lua
+++ b/tests/test-misc.lua
@@ -63,34 +63,19 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.os_homedir", function (print, p, expect, uv)
-    local version = 0x10000 + 9*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.9.0")
-      return
-    end
     local path = assert(uv.os_homedir())
     p(path)
-  end)
+  end, "1.9.0")
 
   test("uv.os_tmpdir", function (print, p, expect, uv)
-    local version = 0x10000 + 9*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.9.0")
-      return
-    end
     local path = assert(uv.os_tmpdir())
     p(path)
-  end)
+  end, "1.9.0")
 
   test("uv.os_get_passwd", function (print, p, expect, uv)
-    local version = 0x10000 + 9*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.9.0")
-      return
-    end
     local passwd = assert(uv.os_get_passwd())
     p(passwd)
-  end)
+  end, "1.9.0")
 
   test("uv.cwd and uv.chdir", function (print, p, expect, uv)
     local old = assert(uv.cwd())
@@ -112,35 +97,20 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.os_uname", function(print, p, expect, uv)
-    local version = 0x10000 + 25*0x100 + 0
-    if uv.version() >= version then
-      local uname = assert(uv.os_uname())
-      p(uname)
-    else
-      print("skipped")
-    end
-  end)
+    local uname = assert(uv.os_uname())
+    p(uname)
+  end, "1.25.0")
 
   test("uv.gettimeofday", function(print, p, expect, uv)
-    local version = 0x10000 + 28*0x100 + 0
-    if uv.version() >= version then
-      local now = os.time()
-      local sec, usec = assert(uv.gettimeofday())
-      print('        os.time', now)
-      print('uv.gettimeofday',string.format("%f",sec+usec/10^9))
-      assert(type(sec)=='number')
-      assert(type(usec)=='number')
-    else
-      print("skipped")
-    end
-  end)
+    local now = os.time()
+    local sec, usec = assert(uv.gettimeofday())
+    print('        os.time', now)
+    print('uv.gettimeofday',string.format("%f",sec+usec/10^9))
+    assert(type(sec)=='number')
+    assert(type(usec)=='number')
+  end, "1.28.0")
 
   test("uv.os_environ", function(print, p, expect, uv)
-    local version = 0x10000 + 31*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.31.0")
-      return
-    end
     local name, name2 = "LUV_TEST_FOO", "LUV_TEST_FOO2";
     local value, value2 = "123456789", ""
 
@@ -150,7 +120,7 @@ return require('lib/tap')(function (test)
     local env = uv.os_environ();
     assert(env[name]==value)
     assert(env[name2]==value2)
-  end)
+  end, "1.31.0")
 
   test("uv.sleep", function(print, p, expect, uv)
     local val = 1000
@@ -164,11 +134,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.random async", function(print, p, expect, uv)
-    local version = 0x10000 + 33*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.33.0")
-      return
-    end
     local len = 256
     assert(uv.random(len, {}, expect(function(err, randomBytes)
       assert(not err)
@@ -177,28 +142,18 @@ return require('lib/tap')(function (test)
       -- it can theoretically fail but its very unlikely
       assert(randomBytes ~= string.rep("\0", len))
     end)))
-  end)
+  end, "1.33.0")
 
   test("uv.random sync", function(print, p, expect, uv)
-    local version = 0x10000 + 33*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.33.0")
-      return
-    end
     local len = 256
     local randomBytes = assert(uv.random(len))
     assert(#randomBytes == len)
     -- this matches the LibUV test
     -- it can theoretically fail but its very unlikely
     assert(randomBytes ~= string.rep("\0", len))
-  end)
+  end, "1.33.0")
 
   test("uv.random errors", function(print, p, expect, uv)
-    local version = 0x10000 + 33*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.33.0")
-      return
-    end
     -- invalid flag
     local _, err = uv.random(0, -1)
     assert(err:match("^EINVAL"))
@@ -206,6 +161,6 @@ return require('lib/tap')(function (test)
     -- invalid len
     _, err = uv.random(-1)
     assert(err:match("^E2BIG"))
-  end)
+  end, "1.33.0")
 
 end)

--- a/tests/test-misc.lua
+++ b/tests/test-misc.lua
@@ -63,16 +63,31 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.os_homedir", function (print, p, expect, uv)
+    local version = 0x10000 + 9*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.9.0")
+      return
+    end
     local path = assert(uv.os_homedir())
     p(path)
   end)
 
   test("uv.os_tmpdir", function (print, p, expect, uv)
+    local version = 0x10000 + 9*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.9.0")
+      return
+    end
     local path = assert(uv.os_tmpdir())
     p(path)
   end)
 
   test("uv.os_get_passwd", function (print, p, expect, uv)
+    local version = 0x10000 + 9*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.9.0")
+      return
+    end
     local passwd = assert(uv.os_get_passwd())
     p(passwd)
   end)
@@ -121,6 +136,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.os_environ", function(print, p, expect, uv)
+    local version = 0x10000 + 31*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.31.0")
+      return
+    end
     local name, name2 = "LUV_TEST_FOO", "LUV_TEST_FOO2";
     local value, value2 = "123456789", ""
 
@@ -144,6 +164,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.random async", function(print, p, expect, uv)
+    local version = 0x10000 + 33*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.33.0")
+      return
+    end
     local len = 256
     assert(uv.random(len, {}, expect(function(err, randomBytes)
       assert(not err)
@@ -155,6 +180,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.random sync", function(print, p, expect, uv)
+    local version = 0x10000 + 33*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.33.0")
+      return
+    end
     local len = 256
     local randomBytes = assert(uv.random(len))
     assert(#randomBytes == len)
@@ -164,6 +194,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("uv.random errors", function(print, p, expect, uv)
+    local version = 0x10000 + 33*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.33.0")
+      return
+    end
     -- invalid flag
     local _, err = uv.random(0, -1)
     assert(err:match("^EINVAL"))

--- a/tests/test-tcp.lua
+++ b/tests/test-tcp.lua
@@ -145,11 +145,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("tcp close reset client", function(print, p, expect, uv)
-    local version = 0x10000 + 32*0x100 + 0
-    if uv.version() < version then
-      print("skipped")
-      return
-    end
     local server = uv.new_tcp()
     assert(uv.tcp_bind(server, "127.0.0.1", 0))
     assert(uv.listen(server, 1, expect(function ()
@@ -189,14 +184,9 @@ return require('lib/tap')(function (test)
       end))
       p{socket=socket,req=req}
     end)))
-  end)
+  end, "1.32.0")
 
   test("tcp close reset after shutdown", function(print, p, expect, uv)
-    local version = 0x10000 + 32*0x100 + 0
-    if uv.version() < version then
-      print("skipped")
-      return
-    end
     local server = uv.new_tcp()
     assert(uv.tcp_bind(server, "127.0.0.1", 0))
     assert(uv.listen(server, 1, expect(function ()
@@ -235,14 +225,9 @@ return require('lib/tap')(function (test)
       end))
       p{socket=socket,req=req}
     end)))
-  end)
+  end, "1.32.0")
 
   test("tcp close reset accepted", function(print, p, expect, uv)
-    local version = 0x10000 + 32*0x100 + 0
-    if uv.version() < version then
-      print("skipped")
-      return
-    end
     local server = uv.new_tcp()
     assert(uv.tcp_bind(server, "127.0.0.1", 0))
     assert(uv.listen(server, 1, expect(function ()
@@ -279,14 +264,9 @@ return require('lib/tap')(function (test)
       end))
       p{socket=socket,req=req}
     end)))
-  end)
+  end, "1.32.0")
 
   test("tcp close reset accepted after shutdown", function(print, p, expect, uv)
-    local version = 0x10000 + 32*0x100 + 0
-    if uv.version() < version then
-      print("skipped")
-      return
-    end
     local server = uv.new_tcp()
     assert(uv.tcp_bind(server, "127.0.0.1", 0))
     assert(uv.listen(server, 1, expect(function ()
@@ -323,5 +303,5 @@ return require('lib/tap')(function (test)
       end))
       p{socket=socket,req=req}
     end)))
-  end)
+  end, "1.32.0")
 end)

--- a/tests/test-thread.lua
+++ b/tests/test-thread.lua
@@ -59,11 +59,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("test thread create with options table", function(print, p, expect, uv)
-    local version = 0x10000 + 26*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.26.0")
-      return
-    end
     local delay = 100
     uv.update_time()
     local before = uv.now()
@@ -85,6 +80,6 @@ return require('lib/tap')(function (test)
       elapsed = elapsed
     })
     assert(elapsed >= 100, "elapsed should be at least delay ")
-  end)
+  end, "1.26.0")
 
 end)

--- a/tests/test-thread.lua
+++ b/tests/test-thread.lua
@@ -59,6 +59,11 @@ return require('lib/tap')(function (test)
   end)
 
   test("test thread create with options table", function(print, p, expect, uv)
+    local version = 0x10000 + 26*0x100 + 0
+    if uv.version() < version then
+      print("skipped, requires libuv >= 1.26.0")
+      return
+    end
     local delay = 100
     uv.update_time()
     local before = uv.now()

--- a/tests/test-udp.lua
+++ b/tests/test-udp.lua
@@ -80,12 +80,6 @@ return require('lib/tap')(function (test)
   end)
 
   test("udp send args", function(print, p, expect, uv)
-    local version = 0x10000 + 27*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.27.0")
-      return
-    end
-
     local udp = uv.new_udp()
 
     local _, err = pcall(function() uv.udp_send(udp, "PING", 5, 5) end)
@@ -98,15 +92,9 @@ return require('lib/tap')(function (test)
     print(assert(err))
 
     uv.close(udp)
-  end)
+  end, "1.27.0")
 
   test("udp connect", function(print, p, expect, uv)
-    local version = 0x10000 + 27*0x100 + 0
-    if uv.version() < version then
-      print("skipped, requires libuv >= 1.27.0")
-      return
-    end
-
     local server = uv.new_udp()
     local client = uv.new_udp()
 
@@ -180,5 +168,5 @@ return require('lib/tap')(function (test)
         assert(not err, err)
       end))
     end)))
-  end)
+  end, "1.27.0")
 end)


### PR DESCRIPTION
This has been tested against Libuv 1.0.0 on Linux and it now compiles and all tests now pass with that setup. No other intermediate versions were tested, though.

Fixes #473, contributes towards #474. The next step would be to start testing against Libuv 1.0.0 in CI.

---

https://github.com/luvit/luv/commit/e431c70b5b37f4a9b3081c24c2da90dc69b8d85b is of particular note.

Skipped test lines now look like:

`ok 102 udp - udp connect # skip Requires libuv >= 1.27.0`

Final output line looks like (when there are skipped tests):

`# All tests passed (33 skipped)`