### PR TITLE
CI: Retry connection to luarocks.org to workaround occasional timeouts

### DIFF
--- a/.ci/setup_lua.sh
+++ b/.ci/setup_lua.sh
@@ -87,7 +87,8 @@ lua -v
 
 LUAROCKS_BASE=luarocks-$LUAROCKS
 
-curl --silent --location "https://luarocks.org/releases/$LUAROCKS_BASE.tar.gz" | tar xz
+# retry 5 times, connection to luarocks.org seems to timeout occassionally
+curl --silent --location --retry 5 "https://luarocks.org/releases/$LUAROCKS_BASE.tar.gz" | tar xz
 
 cd "$LUAROCKS_BASE"
 


### PR DESCRIPTION
This seems to fix the occasional failures. I restarted [this build](https://travis-ci.org/github/squeek502/luv/builds/675931212) a few times and it passed every time.