### PR TITLE
luv_new_udp: Add support for UV_UDP_RECVMMSG

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1888,12 +1888,26 @@ UDP handles encapsulate UDP communication for both clients and servers.
 ### `uv.new_udp([flags])`
 
 **Parameters:**
-- `flags`: `string` or `nil`
+- `flags`: `table` or `nil`
+  - `family`: `string` or `nil`
+  - `mmsgs`: `integer` or `nil` (default: `1`)
 
 Creates and initializes a new `uv_udp_t`. Returns the Lua userdata wrapping
-it. The actual socket is created lazily. Flags may be a family string:
-`"unix"`, `"inet"`, `"inet6"`, `"ipx"`, `"netlink"`, `"x25"`, `"ax25"`,
-`"atmpvc"`, `"appletalk"`, or `"packet"`.
+it. The actual socket is created lazily.
+
+When specified, `family` must be one of `"unix"`, `"inet"`, `"inet6"`,
+`"ipx"`, `"netlink"`, `"x25"`, `"ax25"`, `"atmpvc"`, `"appletalk"`, or
+`"packet"`.
+
+When specified, `mmsgs` determines the number of messages able to be received
+at one time via `recvmmsg(2)` (the allocated buffer will be sized to be able
+to fit the specified number of max size dgrams). Only has an effect on
+platforms that support `recvmmsg(2)`.
+
+**Note:** For backwards compatibility reasons, `flags` can also be a string or
+integer. When it is a string, it will be treated like the `family` key above.
+When it is an integer, it will be used directly as the `flags` parameter when
+calling `uv_udp_init_ex`.
 
 **Returns:** `uv_udp_t userdata` or `fail`
 


### PR DESCRIPTION
See the added comment for my thought process here:

https://github.com/luvit/luv/blob/43fb1183d4599e06ad85df1fc8a4b2782f35a0c4/src/udp.c#L48-L57

Submitting this as a draft because there's still some more things to be figured out:

- There are some bugs that need to be worked out with UV_UDP_RECVMMSG enabled, some of the udp tests are failing
- I think the usefulness of `recvmmsg` depends on the buffer size, which we don't give Lua control of (we use the `suggested_size` from [uv_alloc_cb](http://docs.libuv.org/en/v1.x/handle.html#c.uv_alloc_cb)). Maybe turning on `UV_UDP_RECVMMSG` only makes sense if we also allow changing the size of the recv buffer.
- The parameter of `luv_new_udp` is a little bit strange now, I think we might want to allow it to be passed as a table and have different fields for address family and recvmmsg. This comment is relevant: https://github.com/luvit/luv/issues/399#issuecomment-540185444