### PR TITLE
Add handle_get_type and req_get_type

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -284,6 +284,8 @@ end)
 
 ### `uv.cancel(req)`
 
+> method form `req:cancel()`
+
 **Parameters:**
 - `req`: `userdata` for sub-type of `uv_req_t`
 
@@ -292,6 +294,18 @@ executing. Only cancellation of `uv_fs_t`, `uv_getaddrinfo_t`,
 `uv_getnameinfo_t` and `uv_work_t` requests is currently supported.
 
 **Returns:** `0` or `fail`
+
+### `uv.req_get_type(req)`
+
+> method form `req:get_type()`
+
+**Parameters:**
+- `req`: `userdata` for sub-type of `uv_req_t`
+
+Returns the name of the struct for a given request (e.g. `"fs"` for `uv_fs_t`)
+and the libuv enum integer for the request's type (`uv_req_type`).
+
+**Returns:** `string, integer`
 
 ## `uv_handle_t` — Base handle
 

--- a/docs.md
+++ b/docs.md
@@ -466,6 +466,18 @@ has been closed, this function will return `EBADF`.
 **Warning**: Be very careful when using this function. libuv assumes it's in
 control of the file descriptor so any change to it may lead to malfunction.
 
+### `uv.handle_get_type(handle)`
+
+> method form `handle:get_type()`
+
+**Parameters:**
+- `handle`: `userdata` for sub-type of `uv_handle_t`
+
+Returns the name of the struct for a given handle (e.g. `"pipe"` for `uv_pipe_t`)
+and the libuv enum integer for the handle's type (`uv_handle_type`).
+
+**Returns:** `string, integer`
+
 ## Reference counting
 
 [reference counting]: #reference-counting

--- a/src/handle.c
+++ b/src/handle.c
@@ -188,3 +188,14 @@ static int luv_fileno(lua_State* L) {
   lua_pushinteger(L, (LUA_INTEGER)(ptrdiff_t)fd);
   return 1;
 }
+
+#ifdef LUV_UV_VERSION_GEQ(1, 19, 0)
+static int luv_handle_get_type(lua_State* L) {
+  uv_handle_t* handle = luv_check_handle(L, 1);
+  uv_handle_type type = uv_handle_get_type(handle);
+  const char* type_name = uv_handle_type_name(type);
+  lua_pushstring(L, type_name);
+  lua_pushinteger(L, type);
+  return 2;
+}
+#endif

--- a/src/luv.c
+++ b/src/luv.c
@@ -63,6 +63,9 @@ static const luaL_Reg luv_functions[] = {
 
   // req.c
   {"cancel", luv_cancel},
+#if LUV_UV_VERSION_GEQ(1, 19, 0)
+  {"req_get_type", luv_req_get_type},
+#endif
 
   // handle.c
   {"is_active", luv_is_active},
@@ -584,6 +587,24 @@ static void luv_handle_init(lua_State* L) {
   lua_rawset(L, -3);
 
   lua_setfield(L, LUA_REGISTRYINDEX, "uv_stream");
+}
+
+static const luaL_Reg luv_req_methods[] = {
+  // req.c
+  {"cancel", luv_cancel},
+#if LUV_UV_VERSION_GEQ(1, 19, 0)
+  {"get_type", luv_req_get_type},
+#endif
+  {NULL, NULL}
+};
+
+static void luv_req_init(lua_State* L) {
+  luaL_newmetatable(L, "uv_req");
+  lua_pushcfunction(L, luv_req_tostring);
+  lua_setfield(L, -2, "__tostring");
+  luaL_newlib(L, luv_req_methods);
+  lua_setfield(L, -2, "__index");
+  lua_pop(L, 1);
 }
 
 // Call lua function, will pop nargs values from top of vm stack and push some

--- a/src/luv.c
+++ b/src/luv.c
@@ -74,6 +74,9 @@ static const luaL_Reg luv_functions[] = {
   {"send_buffer_size", luv_send_buffer_size},
   {"recv_buffer_size", luv_recv_buffer_size},
   {"fileno", luv_fileno},
+#if LUV_UV_VERSION_GEQ(1, 19, 0)
+  {"handle_get_type", luv_handle_get_type},
+#endif
 
   // timer.c
   {"new_timer", luv_new_timer},
@@ -370,6 +373,9 @@ static const luaL_Reg luv_handle_methods[] = {
   {"send_buffer_size", luv_send_buffer_size},
   {"recv_buffer_size", luv_recv_buffer_size},
   {"fileno", luv_fileno},
+#if LUV_UV_VERSION_GEQ(1, 19, 0)
+  {"get_type", luv_handle_get_type},
+#endif
   {NULL, NULL}
 };
 

--- a/src/req.c
+++ b/src/req.c
@@ -33,13 +33,6 @@ static int luv_req_tostring(lua_State* L) {
   return 1;
 }
 
-static void luv_req_init(lua_State* L) {
-  luaL_newmetatable (L, "uv_req");
-  lua_pushcfunction(L, luv_req_tostring);
-  lua_setfield(L, -2, "__tostring");
-  lua_pop(L, 1);
-}
-
 // Metamethod to allow storing anything in the userdata's environment
 static int luv_cancel(lua_State* L) {
   uv_req_t* req = (uv_req_t*)luv_check_req(L, 1);
@@ -47,3 +40,14 @@ static int luv_cancel(lua_State* L) {
   // Cleanup occurs when callbacks are ran with UV_ECANCELED status.
   return luv_result(L, ret);
 }
+
+#ifdef LUV_UV_VERSION_GEQ(1, 19, 0)
+static int luv_req_get_type(lua_State* L) {
+  uv_req_t* req = luv_check_req(L, 1);
+  uv_req_type type = uv_req_get_type(req);
+  const char* type_name = uv_req_type_name(type);
+  lua_pushstring(L, type_name);
+  lua_pushinteger(L, type);
+  return 2;
+}
+#endif

--- a/tests/test-handle.lua
+++ b/tests/test-handle.lua
@@ -1,0 +1,16 @@
+return require('lib/tap')(function (test)
+
+  test("get type", function (print, p, expect, uv)
+    local pipe = assert(uv.new_pipe())
+
+    local typename, typeid = pipe:get_type()
+    assert(typename == "pipe")
+
+    local typename_, typeid_ = uv.handle_get_type(pipe)
+    assert(typename == typename_)
+    assert(typeid == typeid_)
+
+    pipe:close()
+  end, "1.19.0")
+
+end)

--- a/tests/test-req.lua
+++ b/tests/test-req.lua
@@ -1,5 +1,23 @@
 return require('lib/tap')(function (test)
 
+  test("cancel", function (print, p, expect, uv)
+    -- might need to try a few times since cancel can fail with EBUSY
+    for _=1,5 do
+      local req = assert(uv.fs_stat('.', expect(function(err)
+        if err then
+          assert(err:match("^ECANCELED"))
+        else
+          assert(not err, err)
+        end
+      end)))
+
+      local _, cancel_err = req:cancel()
+      if cancel_err == nil then
+        break
+      end
+    end
+  end)
+
   test("get type", function (print, p, expect, uv)
     local req = uv.fs_stat('.', expect(function(err)
       assert(not err, err)

--- a/tests/test-req.lua
+++ b/tests/test-req.lua
@@ -1,0 +1,16 @@
+return require('lib/tap')(function (test)
+
+  test("get type", function (print, p, expect, uv)
+    local req = uv.fs_stat('.', expect(function(err)
+      assert(not err, err)
+    end))
+
+    local typename, typeid = req:get_type()
+    assert(typename == "fs")
+
+    local typename_, typeid_ = uv.req_get_type(req)
+    assert(typename == typename_)
+    assert(typeid == typeid_)
+  end, "1.19.0")
+
+end)


### PR DESCRIPTION
- `handle_get_type`: Provides the functionality of both uv_handle_get_type and uv_handle_type_name in one function. Contributes towards #410
- `req_get_type`: Provides the functionality of both uv_req_get_type and uv_req_type_name in one function. Contributes towards #410
- Also adds method form of uv.cancel: req:cancel(). Contributes towards #416