### PR TITLE
Add loop_configure binding

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -200,6 +200,34 @@ specified mode:
 you use the luv bindings directly, you need to call this after registering
 your initial set of event callbacks to start the event loop.
 
+### `uv.loop_configure(option, ...)`
+
+**Parameters:**
+- `option`: `string`
+- `...`: depends on `option`, see below
+
+Set additional loop options. You should normally call this before the first call
+to uv_run() unless mentioned otherwise.
+
+Supported options:
+
+  - `"block_signal"`: Block a signal when polling for new events. The second argument
+  to loop_configure() is the signal name (as a lowercase string) or the signal number.
+  This operation is currently only implemented for `"sigprof"` signals, to suppress
+  unnecessary wakeups when using a sampling profiler. Requesting other signals will
+  fail with `EINVAL`.
+
+An example of a valid call to this function is:
+
+```lua
+uv.loop_configure("block_signal", "sigprof")
+```
+
+**Returns:** `0` or `fail`
+
+**Note:** Be prepared to handle the `ENOSYS` error; it means the loop option is
+not supported by the platform.
+
 ### `uv.loop_alive()`
 
 Returns `true` if there are referenced active handles, active requests, or

--- a/src/loop.c
+++ b/src/loop.c
@@ -94,3 +94,26 @@ static int luv_walk(lua_State* L) {
   uv_walk(luv_loop(L), luv_walk_cb, L);
   return 0;
 }
+
+#if LUV_UV_VERSION_GEQ(1, 0, 2)
+static const char *const luv_loop_configure_options[] = {
+  "block_signal", NULL
+};
+
+static int luv_loop_configure(lua_State* L) {
+  uv_loop_t* loop = luv_loop(L);
+  uv_loop_option option;
+  switch (luaL_checkoption(L, 1, NULL, luv_loop_configure_options)) {
+  case 0: option = UV_LOOP_BLOCK_SIGNAL; break;
+  default: break; /* unreachable */
+  }
+  int ret;
+  if (option == UV_LOOP_BLOCK_SIGNAL) {
+    // lua_isstring checks for string or number
+    luaL_argcheck(L, lua_isstring(L, 2), 2, "block_signal option: expected signal as string or number");
+    int signal = luv_parse_signal(L, 2);
+    ret = uv_loop_configure(loop, UV_LOOP_BLOCK_SIGNAL, signal);
+  }
+  return luv_result(L, ret);
+}
+#endif

--- a/src/luv.c
+++ b/src/luv.c
@@ -60,6 +60,9 @@ static const luaL_Reg luv_functions[] = {
   {"now", luv_now},
   {"update_time", luv_update_time},
   {"walk", luv_walk},
+#if LUV_UV_VERSION_GEQ(1, 0, 2)
+  {"loop_configure", luv_loop_configure},
+#endif
 
   // req.c
   {"cancel", luv_cancel},

--- a/src/private.h
+++ b/src/private.h
@@ -106,6 +106,9 @@ static int luv_optboolean(lua_State*L, int idx, int defaultval);
 /* From thread.c */
 static lua_State* luv_thread_acquire_vm();
 
+/* From process.c */
+static int luv_parse_signal(lua_State* L, int slot);
+
 /* From work.c */
 static const char* luv_thread_dumped(lua_State* L, int idx, size_t* l);
 static const char* luv_getmtname(lua_State *L, int idx);


### PR DESCRIPTION
Contributes towards #410, implements #103

There's no test case added because it would affect the loop for all other tests (there's no way to undo `"block_signal", "sigprof"` once it's set). I did make sure that `uv.loop_configure("block_signal", "sigprof")` succeeds on Linux, though.