### PR TITLE
Update Lua version check

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -16,7 +16,7 @@
  */
 
 #include <lua.h>
-#if (LUA_VERSION_NUM != 503)
+#if (LUA_VERSION_NUM < 503)
 #include "compat-5.3.h"
 #endif
 #include "luv.h"

--- a/src/private.h
+++ b/src/private.h
@@ -2,7 +2,7 @@
 #define LUV_PRIVATE_H
 
 #include <lua.h>
-#if (LUA_VERSION_NUM != 503)
+#if (LUA_VERSION_NUM < 503)
 #include "compat-5.3.h"
 #endif
 


### PR DESCRIPTION
Building using the new Lua 5.4 version fails due to the included file `compat-5.3.h`