### PR TITLE
Tune garbage collector to be extremely aggressive during Valgrind/ASAN tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ jobs:
         - WITH_LUA_ENGINE=Lua
       script:
         - CMAKE_OPTIONS="-DCMAKE_C_FLAGS=-fsanitize=address,undefined" make && make test
+        # Run with extremely aggressive garbage collection to potentially find more problems
+        - ./build/lua -e "collectgarbage('setpause', 0); collectgarbage('setstepmul', 10000000000000)" tests/run.lua
     - name: valgrind
       os: linux
       # Need a more up-to-date Valgrind to dodge https://bugs.kde.org/show_bug.cgi?id=381289
@@ -76,7 +78,7 @@ jobs:
         # --suppressions should be removed once
         # https://github.com/libuv/libuv/issues/2840
         # is closed and we update to the fixed libuv
-        - valgrind --suppressions=.ci/libuv2840.supp --error-exitcode=1 --leak-check=full --child-silent-after-fork=yes ./build/lua tests/run.lua
+        - valgrind --suppressions=.ci/libuv2840.supp --error-exitcode=1 --leak-check=full --child-silent-after-fork=yes ./build/lua -e "collectgarbage('setpause', 0); collectgarbage('setstepmul', 10000000000000)" tests/run.lua
     - name: process cleanup test
       os: linux
       env:


### PR DESCRIPTION
This should allow us to catch otherwise hard-to-reproduce bugs where things can sometimes be garbage collected before they are used, like https://github.com/luvit/luv/issues/507 and https://github.com/luvit/luv/issues/510

Closes #510