### PR TITLE
Adds uv.loop_mode function

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -231,6 +231,13 @@ uv.loop_configure("block_signal", "sigprof")
 **Note:** Be prepared to handle the `ENOSYS` error; it means the loop option is
 not supported by the platform.
 
+### `uv.loop_mode()`
+
+If the loop is running, returns a string indicating the mode in use. If the loop
+is not running, `nil` is returned instead.
+
+**Returns:** `string` or `nil`
+
 ### `uv.loop_alive()`
 
 Returns `true` if there are referenced active handles, active requests, or

--- a/src/loop.c
+++ b/src/loop.c
@@ -31,9 +31,22 @@ static const char *const luv_runmodes[] = {
 
 static int luv_run(lua_State* L) {
   int mode = luaL_checkoption(L, 1, "default", luv_runmodes);
-  int ret = uv_run(luv_loop(L), (uv_run_mode)mode);
+  luv_ctx_t* ctx = luv_context(L);
+  ctx->mode = mode;
+  int ret = uv_run(ctx->loop, (uv_run_mode)mode);
+  ctx->mode = -1;
   if (ret < 0) return luv_error(L, ret);
   lua_pushboolean(L, ret);
+  return 1;
+}
+
+static int luv_loop_mode(lua_State* L) {
+  luv_ctx_t* ctx = luv_context(L);
+  if (ctx->mode == -1) {
+    lua_pushnil(L);
+  } else {
+    lua_pushstring(L, luv_runmodes[ctx->mode]);
+  }
   return 1;
 }
 

--- a/src/luv.c
+++ b/src/luv.c
@@ -54,6 +54,7 @@ static const luaL_Reg luv_functions[] = {
   // loop.c
   {"loop_close", luv_loop_close},
   {"run", luv_run},
+  {"loop_mode", luv_loop_mode},
   {"loop_alive", luv_loop_alive},
   {"stop", luv_stop},
   {"backend_fd", luv_backend_fd},
@@ -716,6 +717,7 @@ LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop) {
 
   ctx->loop = loop;
   ctx->L = L;
+  ctx->mode = -1;
 }
 
 // Set an external event callback routine, before luaopen_luv
@@ -775,6 +777,7 @@ LUALIB_API int luaopen_luv (lua_State* L) {
 
     ctx->loop = loop;
     ctx->L = L;
+    ctx->mode = -1;
 
     ret = uv_loop_init(loop);
     if (ret < 0) {

--- a/src/luv.h
+++ b/src/luv.h
@@ -79,6 +79,7 @@ typedef struct {
   uv_loop_t*   loop;        /* main loop */
   lua_State*   L;           /* main thread,ensure coroutines works */
   luv_CFpcall  pcall;       /* luv event callback function in protected mode */
+  int          mode;        /* the mode used to run the loop (-1 if not running) */
 
   void* extra;              /* extra data */
 } luv_ctx_t;

--- a/tests/test-loop.lua
+++ b/tests/test-loop.lua
@@ -1,0 +1,13 @@
+return require('lib/tap')(function (test)
+
+	test("uv.loop_mode", function (print, p, expect, uv)
+		assert(uv.loop_mode() == nil)
+    local timer = uv.new_timer()
+    uv.timer_start(timer, 100, 0, expect(function ()
+      assert(uv.loop_mode() == "default")
+      uv.timer_stop(timer)
+      uv.close(timer)
+    end))
+  end)
+
+end)


### PR DESCRIPTION
Closes #498.

I originally wrote a `loop_running` function, but thought that returning the mode is potentially more useful than just `true/false`, so wrote this instead.

Note that`ctx->mode` has to be initialized to `-1` for this to work as expected. That's a potential point of failure, but I think it will be okay.