### PR TITLE
fix a memroy bugs in thread pool work callback

### DIFF
--- a/src/work.c
+++ b/src/work.c
@@ -96,9 +96,10 @@ static void luv_work_cb(uv_work_t* req) {
     i = luv_cfpcall(L, i, LUA_MULTRET, 0);
     if ( i>=0 ) {
       //clear in main threads, luv_after_work_cb
-      i = luv_thread_arg_set(L, &work->rets, top + 1, lua_gettop(L), LUVF_THREAD_SIDE_CHILD);
+      i = luv_thread_arg_set(L, &work->rets, top + 1, lua_gettop(L),
+          LUVF_THREAD_MODE_ASYNC|LUVF_THREAD_SIDE_CHILD);
       lua_pop(L, i);  // pop all returned value
-      luv_thread_arg_clear(L, &work->rets, LUVF_THREAD_SIDE_CHILD);
+      luv_thread_arg_clear(L, &work->rets, LUVF_THREAD_MODE_ASYNC|LUVF_THREAD_SIDE_CHILD);
     }
     luv_thread_arg_clear(L, &work->args, LUVF_THREAD_SIDE_CHILD);
   } else {
@@ -136,7 +137,7 @@ static void luv_after_work_cb(uv_work_t* req, int status) {
   work->ref = LUA_NOREF;
 
   luv_thread_arg_clear(L, &work->args, LUVF_THREAD_SIDE_MAIN);
-  luv_thread_arg_clear(L, &work->rets, LUVF_THREAD_SIDE_MAIN);
+  luv_thread_arg_clear(L, &work->rets, LUVF_THREAD_MODE_ASYNC|LUVF_THREAD_SIDE_MAIN);
   free(work);
 }
 


### PR DESCRIPTION
In thread pool, args passed to work callback maybe gc, use LUVF_THREAD_MODE_ASYNC flags to avoid.