### PR TITLE
Fix possible memory leak in lhandle.c

### DIFF
--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -37,6 +37,7 @@ static luv_handle_t* luv_setup_handle(lua_State* L, luv_ctx_t* ctx) {
   switch (handle->type) {
     UV_HANDLE_TYPE_MAP(XX)
     default:
+      free(data);
       luaL_error(L, "Unknown handle type");
       return NULL;
   }


### PR DESCRIPTION
```data``` is not freed in the default (error) branch.
Thanks,