### PR TITLE
fix memleaks in luv_cpu_info

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -222,10 +222,14 @@ static int luv_getrusage(lua_State* L) {
 }
 
 static int luv_cpu_info(lua_State* L) {
-  uv_cpu_info_t* cpu_infos;
-  int count, i;
+  uv_cpu_info_t* cpu_infos = NULL;
+  int count = 0, i;
   int ret = uv_cpu_info(&cpu_infos, &count);
-  if (ret < 0) return luv_error(L, ret);
+  if (ret < 0)
+  {
+    uv_free_cpu_info(cpu_infos, count);
+    return luv_error(L, ret);
+  }
   lua_newtable(L);
 
   for (i = 0; i < count; i++) {


### PR DESCRIPTION
`uv_cpu_info` Gets information about the CPUs on the system.
The cpu_infos array will have count elements and needs to be freed with uv_free_cpu_info().
`uv_free_cpu_info` should be called when get cpu info fail.

I found this bug when enable AddressSenilizer, when handle:close() for uv_cpu_info.
```
=================================================================
==26121==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 336 byte(s) in 7 object(s) allocated from:
    #0 0x101d4edc2 in __sanitizer_mz_calloc+0x92 (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x46dc2)
    #1 0x7fff20171eb6 in _malloc_zone_calloc+0x3a (libsystem_malloc.dylib:x86_64+0x1beb6)
    #2 0x7fff203ac180 in _CFRuntimeCreateInstance+0x124 (CoreFoundation:x86_64h+0x4180)
    #3 0x7fff203ab906 in __CFStringCreateImmutableFunnel3+0x84d (CoreFoundation:x86_64h+0x3906)
    #4 0x7fff203ab0a1 in CFStringCreateWithCString+0x48 (CoreFoundation:x86_64h+0x30a1)
    #5 0x101150371 in uv__get_cpu_speed darwin.c:267
    #6 0x10114e8ae in uv_cpu_info darwin.c:338
    #7 0x100e22053 in luv_cpu_info misc.c:227
    #8 0x1010bde14 in lj_BC_FUNCC+0x43 (luvi-Darwin_x86_64:x86_64+0x100944e14)

Direct leak of 224 byte(s) in 7 object(s) allocated from:
    #0 0x101d4edc2 in __sanitizer_mz_calloc+0x92 (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x46dc2)
    #1 0x7fff20171eb6 in _malloc_zone_calloc+0x3a (libsystem_malloc.dylib:x86_64+0x1beb6)
    #2 0x7fff203ac180 in _CFRuntimeCreateInstanc%
```