### PR TITLE
fs: Print destination paths in error messages for the relevant functions

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -380,6 +380,20 @@ static void luv_fs_cb(uv_fs_t* req) {
   }
 }
 
+static int fs_req_has_dest_path(uv_fs_t* req) {
+  switch (req->fs_type) {
+    case UV_FS_RENAME:
+    case UV_FS_SYMLINK:
+    case UV_FS_LINK:
+#if LUV_UV_VERSION_GEQ(1, 14, 0)
+    case UV_FS_COPYFILE:
+#endif
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 // handle the FS call but don't return, instead set the local
 // variable 'nargs' to the number of return values
 #define FS_CALL_NORETURN(func, req, ...) {                \
@@ -390,7 +404,16 @@ static void luv_fs_cb(uv_fs_t* req) {
                      sync ? NULL : luv_fs_cb);            \
   if (req->fs_type != UV_FS_ACCESS && ret < 0) {          \
     lua_pushnil(L);                                       \
-    if (req->path) {                                      \
+    if (fs_req_has_dest_path(req)) {                      \
+      lua_rawgeti(L, LUA_REGISTRYINDEX, data->data_ref);  \
+      const char* dest_path = lua_tostring(L, -1);        \
+      lua_pop(L, 1);                                      \
+      lua_pushfstring(L, "%s: %s: %s -> %s",              \
+          uv_err_name(req->result),                       \
+          uv_strerror(req->result),                       \
+          req->path, dest_path);                          \
+    }                                                     \
+    else if (req->path) {                                 \
       lua_pushfstring(L, "%s: %s: %s",                    \
           uv_err_name(req->result),                       \
           uv_strerror(req->result), req->path);           \
@@ -604,6 +627,9 @@ static int luv_fs_rename(lua_State* L) {
   int ref = luv_check_continuation(L, 3);
   uv_fs_t* req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
+  // ref the dest path so that we can print it in the error message
+  lua_pushvalue(L, 2);
+  ((luv_req_t*)req->data)->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   FS_CALL(rename, req, path, new_path);
 }
 
@@ -719,6 +745,9 @@ static int luv_fs_link(lua_State* L) {
   int ref = luv_check_continuation(L, 3);
   uv_fs_t* req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
+  // ref the dest path so that we can print it in the error message
+  lua_pushvalue(L, 2);
+  ((luv_req_t*)req->data)->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   FS_CALL(link, req, path, new_path);
 }
 
@@ -739,7 +768,9 @@ static int luv_fs_symlink(lua_State* L) {
   ref = luv_check_continuation(L, 4);
   req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
-
+  // ref the dest path so that we can print it in the error message
+  lua_pushvalue(L, 2);
+  ((luv_req_t*)req->data)->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   FS_CALL(symlink, req, path, new_path, flags);
 }
 
@@ -824,6 +855,9 @@ static int luv_fs_copyfile(lua_State*L) {
   ref = luv_check_continuation(L, 4);
   req = (uv_fs_t*)lua_newuserdata(L, sizeof(*req));
   req->data = luv_setup_req(L, ctx, ref);
+  // ref the dest path so that we can print it in the error message
+  lua_pushvalue(L, 2);
+  ((luv_req_t*)req->data)->data_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   FS_CALL(copyfile, req, path, new_path, flags);
 }
 #endif

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -334,9 +334,10 @@ return require('lib/tap')(function (test)
 
   test("errors with dest paths", function (print, p, expect, uv)
     -- this combination will cause all of the functions below to fail
-    local fd1, path1 = assert(uv.fs_mkstemp("luvXXXXXX"))
+    local path1, path2 = "_test_", "_testdir_"
+    local fd1 = assert(uv.fs_open(path1, "w", 438))
     assert(uv.fs_close(fd1))
-    local path2 = assert(uv.fs_mkdtemp("luvXXXXXX"))
+    assert(uv.fs_mkdir(path2, tonumber('777', 8)))
 
     local fns = {"fs_rename", "fs_link", "fs_symlink", "fs_copyfile"}
     for _, fn_name in ipairs(fns) do

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -331,4 +331,24 @@ return require('lib/tap')(function (test)
     assert(err:match("^EINVAL:"))
     assert(code=='EINVAL')
   end, "1.34.0")
+
+  test("errors with dest paths", function (print, p, expect, uv)
+    -- this combination will cause all of the functions below to fail
+    local fd1, path1 = assert(uv.fs_mkstemp("luvXXXXXX"))
+    assert(uv.fs_close(fd1))
+    local path2 = assert(uv.fs_mkdtemp("luvXXXXXX"))
+
+    local fns = {"fs_rename", "fs_link", "fs_symlink", "fs_copyfile"}
+    for _, fn_name in ipairs(fns) do
+      if uv[fn_name] then
+        local fn = uv[fn_name]
+        local ok, err, code = fn(path1, path2)
+        p(fn_name, ok, err, code)
+        assert(not ok)
+      end
+    end
+
+    assert(uv.fs_unlink(path1))
+    assert(uv.fs_rmdir(path2))
+  end)
 end)


### PR DESCRIPTION
Output of the added test, before (note that the relevant path for each of these errors messages is actually the destination, not the source):
```
  "fs_rename"	"EISDIR: illegal operation on a directory: luv7TbDmb"
  "fs_link"	"EEXIST: file already exists: luv7TbDmb"
  "fs_symlink"	"EEXIST: file already exists: luv7TbDmb"
  "fs_copyfile"	"EISDIR: illegal operation on a directory: luv7TbDmb"
```
After:
```
  "fs_rename"	"EISDIR: illegal operation on a directory: luv7TbDmb -> luvQzLgbb"
  "fs_link"	"EEXIST: file already exists: luv7TbDmb -> luvQzLgbb"
  "fs_symlink"	"EEXIST: file already exists: luv7TbDmb -> luvQzLgbb"
  "fs_copyfile"	"EISDIR: illegal operation on a directory: luv7TbDmb -> luvQzLgbb"
```