### PR TITLE
Fix protocol being treated as family in getaddrinfo inputs/outputs 

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1939,7 +1939,7 @@ Gets the current Window width and height.
 Controls whether console virtual terminal sequences are processed by libuv or
 console. Useful in particular for enabling ConEmu support of ANSI X3.64 and
 Xterm 256 colors. Otherwise Windows10 consoles are usually detected
-automatically. State may be a family string: `"supported"` or `"unsupported"`.
+automatically. State should be one of: `"supported"` or `"unsupported"`.
 
 This function is only meaningful on Windows systems. On Unix it is silently
 ignored.
@@ -3086,9 +3086,9 @@ called in the main loop thread.
 - `host`: `string` or `nil`
 - `service`: `string` or `nil`
 - `hints`: `table` or `nil`
-  - `family`: `integer` or `string` or `nil`
-  - `socktype`: `integer` or `string` or `nil`
-  - `protocol`: `integer` or `string` or `nil`
+  - `family`: `string` or `integer` or `nil`
+  - `socktype`: `string` or `integer` or `nil`
+  - `protocol`: `string` or `integer` or `nil`
   - `addrconfig`: `boolean` or `nil`
   - `v4mapped`: `boolean` or `nil`
   - `all`: `boolean` or `nil`
@@ -3102,6 +3102,13 @@ called in the main loop thread.
 
 Equivalent to `getaddrinfo(3)`. Either `node` or `service` may be `nil` but not
 both.
+
+Valid hint strings for the keys that take a string:
+- `family`: `"unix"`, `"inet"`, `"inet6"`, `"ipx"`,
+`"netlink"`, `"x25"`, `"ax25"`, `"atmpvc"`, `"appletalk"`, or `"packet"`
+- `socktype`: `"stream"`, `"dgram"`, `"raw"`,
+`"rdm"`, or `"seqpacket"`
+- `protocol`: will be looked up using the `getprotobyname(3)` function (examples: `"ip"`, `"icmp"`, `"tcp"`, `"udp"`, etc)
 
 **Returns (sync version):** `table` or `fail`
 - `[1, 2, 3, ..., n]` : `table`
@@ -3127,6 +3134,9 @@ both.
   - `service`: `string` or `nil`
 
 Equivalent to `getnameinfo(3)`.
+
+When specified, `family` must be one of `"unix"`, `"inet"`, `"inet6"`, `"ipx"`,
+`"netlink"`, `"x25"`, `"ax25"`, `"atmpvc"`, `"appletalk"`, or `"packet"`.
 
 **Returns (sync version):** `string, string` or `fail`
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -675,3 +675,9 @@ static int luv_proto_string_to_num(const char* string) {
   if (!proto) return -1;
   return proto->p_proto;
 }
+
+static const char* luv_proto_num_to_string(int num) {
+  struct protoent* proto = getprotobynumber(num);
+  if (!proto) return NULL;
+  return proto->p_name;
+}

--- a/src/dns.c
+++ b/src/dns.c
@@ -49,7 +49,7 @@ static void luv_pushaddrinfo(lua_State* L, struct addrinfo* res) {
       }
       lua_pushstring(L, luv_sock_num_to_string(curr->ai_socktype));
       lua_setfield(L, -2, "socktype");
-      lua_pushstring(L, luv_af_num_to_string(curr->ai_protocol));
+      lua_pushstring(L, luv_proto_num_to_string(curr->ai_protocol));
       lua_setfield(L, -2, "protocol");
       if (curr->ai_canonname) {
         lua_pushstring(L, curr->ai_canonname);
@@ -134,13 +134,11 @@ static int luv_getaddrinfo(lua_State* L) {
       hints->ai_protocol = lua_tointeger(L, -1);
     }
     else if (lua_isstring(L, -1)) {
-      int protocol = luv_af_string_to_num(lua_tostring(L, -1));
-      if (protocol) {
-        hints->ai_protocol = protocol;
+      int protocol = luv_proto_string_to_num(lua_tostring(L, -1));
+      if (protocol < 0) {
+        return luaL_argerror(L, 3, lua_pushfstring(L, "invalid protocol: %s", lua_tostring(L, -1)));
       }
-      else {
-        return luaL_argerror(L, 3, "Invalid protocol hint");
-      }
+      hints->ai_protocol = protocol;
     }
     else if (!lua_isnil(L, -1)) {
       return luaL_argerror(L, 3, "protocol hint must be string if set");

--- a/src/private.h
+++ b/src/private.h
@@ -83,6 +83,7 @@ static const char* luv_sock_num_to_string(const int num);
 static int luv_sig_string_to_num(const char* string);
 static const char* luv_sig_num_to_string(const int num);
 static int luv_proto_string_to_num(const char* string);
+static const char* luv_proto_num_to_string(int num);
 
 /* From util.c */
 // Push a Libuv error code onto the Lua stack


### PR DESCRIPTION
Follow up to https://github.com/luvit/luv/pull/534#issuecomment-821902777

The `Get all adresses for luvit.io` test in `test-dns.lua` now gives:

```
    { addr = "206.189.225.172", family = "inet", protocol = "tcp", socktype = "stream" },
    { addr = "206.189.225.172", family = "inet", protocol = "udp", socktype = "dgram" },
    { addr = "206.189.225.172", family = "inet", protocol = "ip", socktype = "raw" },
    { addr = "2604:a880:400:d0::1b9f:2001", family = "inet6", protocol = "tcp", socktype = "stream" },
    { addr = "2604:a880:400:d0::1b9f:2001", family = "inet6", protocol = "udp", socktype = "dgram" },
    { addr = "2604:a880:400:d0::1b9f:2001", family = "inet6", protocol = "ip", socktype = "raw" }
```

which has the correct protocols.

---

Protocol hinting also works, e.g.

```lua
local uv = require('luv')

uv.getaddrinfo("luvit.io", nil, {
  protocol = "udp",
}, function (err, res)
  assert(not err, err)
  for i, addr in ipairs(res) do
    print("["..i.."]:")
    for k,v in pairs(addr) do
      print('',k,v)
    end
  end
end)

uv.run()
```

will give

```
[1]:
	addr	206.189.225.172
	family	inet
	socktype	dgram
	protocol	udp
[2]:
	addr	2604:a880:400:d0::1b9f:2001
	family	inet6
	socktype	dgram
	protocol	udp
```