### PR TITLE
rockspec: Use library file given by LuaRocks instead of trying to find it ourselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if (LUA)
   MESSAGE(STATUS "Lua: using information from luarocks")
 
   MESSAGE(STATUS "LUA_LIBDIR: " ${LUA_LIBDIR})
+  MESSAGE(STATUS "LUA_LIBFILE: " ${LUA_LIBFILE})
   MESSAGE(STATUS "LUA_INCDIR: " ${LUA_INCDIR})
   MESSAGE(STATUS "LUA: " ${LUA})
 
@@ -86,19 +87,12 @@ if (LUA)
 
   SET(INSTALL_LIB_DIR ${LIBDIR})
 
-  GET_FILENAME_COMPONENT(LUA_EXEC_NAME ${LUA_EXECUTABLE} NAME_WE)
-  IF(LUA_EXEC_NAME STREQUAL "luajit")
-  FIND_LIBRARY(LUA_LIBRARIES
-    NAMES luajit libluajit
-    PATHS ${LUA_LIBDIR}
-    NO_DEFAULT_PATH)
-  ELSEIF(LUA_EXEC_NAME MATCHES "lua.*")
-    FIND_LIBRARY(LUA_LIBRARIES
-      NAMES lua lua54 lua53 lua52 lua51 liblua liblua54 liblua53 liblua52 liblua51
-      PATHS ${LUA_LIBDIR}
-      NO_DEFAULT_PATH)
-  ENDIF()
-  MESSAGE(STATUS "Lua library: ${LUA_LIBRARIES}")
+  if (LUA_LIBDIR)
+    get_filename_component(LUA_LIBRARIES "${LUA_LIBDIR}/${LUA_LIBFILE}" ABSOLUTE)
+    MESSAGE(STATUS "Lua library: ${LUA_LIBRARIES}")
+  else()
+    MESSAGE(STATUS "Lua library not set, presuming LuaRocks config has link_lua_explicitly set to false")
+  endif()
 
   include_directories(${LUA_INCLUDE_DIR})
 else (LUA)

--- a/luv-scm-0.rockspec
+++ b/luv-scm-0.rockspec
@@ -27,6 +27,7 @@ build = {
      CMAKE_MODULE_LINKER_FLAGS="$(LIBFLAG)",
      LUA_LIBDIR="$(LUA_LIBDIR)",
      LUA_INCDIR="$(LUA_INCDIR)",
+     LUA_LIBFILE="$(LUALIB)",
      LUA="$(LUA)",
      LIBDIR="$(LIBDIR)",
      LUADIR="$(LUADIR)",


### PR DESCRIPTION
LuaRocks can provide LUALIB and LUA_LIBDIR variables which should be better than trying to find the right library file ourselves.

Note: it does not provide them if the LuaRocks config setting `link_lua_explicitly` is false, so LuaRocks will give the following warnings in that case:

    Warning: unmatched variable LUALIB
    Warning: unmatched variable LUA_LIBDIR

These warnings happens on Linux and Mac, since they don't link against the Lua libraries. I'm not sure if there's a clean way to avoid the warnings.

Attempts to address #523.