### PR TITLE
Fix thread dumping in Lua 5.4.3+

### DIFF
--- a/.ci/setup_lua.sh
+++ b/.ci/setup_lua.sh
@@ -70,8 +70,8 @@ else
     curl --silent https://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
     cd lua-5.3.2;
   elif [ "$LUA" == "lua5.4" ]; then
-    curl --silent https://www.lua.org/ftp/lua-5.4.1.tar.gz | tar xz
-    cd lua-5.4.1;
+    curl --silent https://www.lua.org/ftp/lua-5.4.3.tar.gz | tar xz
+    cd lua-5.4.3;
   fi
 
   # Build Lua without backwards compatibility for testing
@@ -133,5 +133,5 @@ elif [ "$LUA" == "lua5.2" ]; then
 elif [ "$LUA" == "lua5.3" ]; then
   rm -rf lua-5.3.2;
 elif [ "$LUA" == "lua5.4" ]; then
-  rm -rf lua-5.4.1;
+  rm -rf lua-5.4.3;
 fi


### PR DESCRIPTION
luaL_buffinit apparently can push things onto the stack (although this is undocumented in the Lua 5.4 manual), so it needs to be called after lua_dump to make sure the function to-be-dumped is still at the top of the stack in lua_dump

Closes #553