### PR TITLE
Add docs coverage script + fix documentation using what it found

### DIFF
--- a/.ci/docscov.sh
+++ b/.ci/docscov.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+undocumented_functions=0
+
+if [[ ! -f src/luv.c ]] ; then
+	echo "Missing src/luv.c"
+	exit 1
+fi
+
+func_definitions=$(sed -n '/luaL_Reg luv_functions\[\] = {$/,/^};$/{p;/^\};$/q}' src/luv.c)
+funcs_start_line_number=$(awk '/luaL_Reg luv_functions\[\] = \{/ {print FNR}' src/luv.c)
+after_funcs=$((funcs_start_line_number+1))
+method_definitions=$(tail -n +$after_funcs src/luv.c | sed -n '/luaL_Reg/,/^\};$/p')
+
+for fn in `echo "$func_definitions" | grep -oP "\s+ \{\"\K([^\"]+)(?=\",)"`; do
+	# count instances of '### `uv.fn_name' in the docs
+	count=$(grep -oPc "^#+\s+\`uv\.$fn\b" docs.md)
+
+	if [ $count -eq 0 ] ; then
+		echo $fn
+		undocumented_functions=$((undocumented_functions+1))
+	fi
+done
+
+for fn in `echo "$method_definitions" | grep -oP "\s+ \{\"\K([^\"]+)(?=\",)"`; do
+	# count instances of '> method form something:fn_name' in the docs
+	count=$(grep -oPc "^> method form [^:]+:$fn\b" docs.md)
+
+	if [ $count -eq 0 ] ; then
+		echo "$fn (method form)"
+		undocumented_functions=$((undocumented_functions+1))
+	fi
+done
+
+exit $undocumented_functions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - run: ./.ci/bindcov.sh
+    - name: Bindings
+      run: ./.ci/bindcov.sh
+    - name: Docs
+      run: ./.ci/docscov.sh
 
   clang-asan:
     runs-on: ubuntu-latest

--- a/docs.md
+++ b/docs.md
@@ -2014,7 +2014,7 @@ Returns the handle's send queue size.
 
 ### `uv.udp_get_send_queue_count()`
 
-> method form `udp:get_send_count_size()`
+> method form `udp:get_send_queue_count()`
 
 Returns the handle's send queue count.
 
@@ -2988,6 +2988,8 @@ that should be returned by each call to `uv.fs_readdir()`.
 
 ### `uv.fs_readdir(dir, [callback])`
 
+> method form `dir:readdir([callback])`
+
 **Parameters:**
 - `dir`: `uv_dir_t userdata`
 - `callback`: `callable` (async version) or `nil` (sync version)
@@ -3007,6 +3009,8 @@ the associated `uv.fs_opendir()` call.
 **Returns (async version):** `uv_fs_t userdata`
 
 ### `uv.fs_closedir(dir, [callback])`
+
+> method form `dir:closedir([callback])`
 
 **Parameters:**
 - `dir`: `uv_dir_t userdata`
@@ -3606,6 +3610,15 @@ low on entropy.
 **Returns (sync version):** `string` or `fail`
 
 **Returns (async version):** `0` or `fail`
+
+### `uv.translate_sys_error(errcode)`
+
+**Parameters:**
+- `errcode`: `integer`
+
+Returns the libuv error message and error name (both in string form, see [`err` and `name` in Error Handling](#error-handling)) equivalent to the given platform dependent error code: POSIX error codes on Unix (the ones stored in errno), and Win32 error codes on Windows (those returned by GetLastError() or WSAGetLastError()).
+
+**Returns:** `string, string` or `nil`
 
 ## Metrics operations
 


### PR DESCRIPTION
Adds a docscov.sh script that runs in CI to check `luv.c` against `docs.md` to see if there are any functions that are defined in luv.c but not documented in docs.md. Compliments the existing bindcov.sh and will help make sure we document any newly bound functions in the future.

Also updates `docs.md` to fix all the undocumented functions that docscov.sh initially found.