### PR TITLE
Add function to run thread in protected mode

### DIFF
--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -98,7 +98,7 @@ static void luv_call_callback(lua_State* L, luv_handle_t* data, luv_callback_id 
       lua_insert(L, -1 - nargs);
     }
 
-    ctx->pcall(L, nargs, 0, 0);
+    ctx->cb_pcall(L, nargs, 0, 0);
   }
 }
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -99,7 +99,7 @@ static void luv_walk_cb(uv_handle_t* handle, void* arg) {
 
   lua_pushvalue(L, 1);           // Copy the function
   luv_find_handle(L, data);      // Get the userdata
-  data->ctx->pcall(L, 1, 0, 0);  // Call the function
+  data->ctx->cb_pcall(L, 1, 0, 0);  // Call the function
 }
 
 static int luv_walk(lua_State* L) {

--- a/src/lreq.c
+++ b/src/lreq.c
@@ -59,7 +59,7 @@ static void luv_fulfill_req(lua_State* L, luv_req_t* data, int nargs) {
     if (nargs) {
       lua_insert(L, -1 - nargs);
     }
-    data->ctx->pcall(L, nargs, 0, 0);
+    data->ctx->cb_pcall(L, nargs, 0, 0);
   }
 }
 

--- a/src/luv.c
+++ b/src/luv.c
@@ -741,7 +741,13 @@ LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop) {
 // Set an external event callback routine, before luaopen_luv
 LUALIB_API void luv_set_callback(lua_State* L, luv_CFpcall pcall) {
   luv_ctx_t* ctx = luv_context(L);
-  ctx->pcall = pcall;
+  ctx->cb_pcall = pcall;
+}
+
+// Set an external thread routine, before luaopen_luv
+LUALIB_API void luv_set_thread(lua_State* L, luv_CFpcall pcall) {
+  luv_ctx_t* ctx = luv_context(L);
+  ctx->thrd_pcall = pcall;
 }
 
 static void walk_cb(uv_handle_t *handle, void *arg)
@@ -803,8 +809,13 @@ LUALIB_API int luaopen_luv (lua_State* L) {
     }
   }
   // pcall is NULL, luv use default callback routine
-  if (ctx->pcall==NULL) {
-    ctx->pcall = luv_cfpcall;
+  if (ctx->cb_pcall==NULL) {
+    ctx->cb_pcall = luv_cfpcall;
+  }
+
+  // pcall is NULL, luv use default thread routine
+  if (ctx->thrd_pcall==NULL) {
+    ctx->thrd_pcall = luv_cfpcall;
   }
 
   luv_req_init(L);

--- a/src/luv.h
+++ b/src/luv.h
@@ -90,7 +90,8 @@ LUALIB_API int luv_cfpcall(lua_State* L, int nargs, int nresult, int flags);
 typedef struct {
   uv_loop_t*   loop;        /* main loop */
   lua_State*   L;           /* main thread,ensure coroutines works */
-  luv_CFpcall  pcall;       /* luv event callback function in protected mode */
+  luv_CFpcall  cb_pcall;    /* luv event callback function in protected mode */
+  luv_CFpcall  thrd_pcall;  /* luv thread function in protected mode*/
   int          mode;        /* the mode used to run the loop (-1 if not running) */
 
   void* extra;              /* extra data */
@@ -118,6 +119,13 @@ LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop);
    (otherwise luv will use the default callback function: luv_cfpcall)
 */
 LUALIB_API void luv_set_callback(lua_State* L, luv_CFpcall pcall);
+
+/* Set or clear an external c routine for luv thread When using
+ * a custom/external function, this must be called before luaopen_luv
+ * in the function that create the lua_State of the thread
+   (otherwise luv will use the default callback function: luv_cfpcall)
+*/
+LUALIB_API void luv_set_thread(lua_State* L, luv_CFpcall pcall);
 
 /* This is the main hook to load the library.
    This can be called multiple times in a process as long

--- a/src/thread.c
+++ b/src/thread.c
@@ -271,13 +271,14 @@ static void luv_thread_cb(void* varg) {
   //acquire vm and get top
   luv_thread_t* thd = (luv_thread_t*)varg;
   lua_State* L = acquire_vm_cb();
+  luv_ctx_t *ctx = luv_context(L);
 
   //push lua function, thread entry
   if (luaL_loadbuffer(L, thd->code, thd->len, "=thread") == 0) {
     //push parameter for real thread function
     int i = luv_thread_arg_push(L, &thd->args, LUVF_THREAD_SIDE_CHILD);
 
-    luv_cfpcall(L, i, 0, 0);
+    ctx->thrd_pcall(L, i, 0, 0);
     luv_thread_arg_clear(L, &thd->args, LUVF_THREAD_SIDE_CHILD);
   } else {
     fprintf(stderr, "Uncaught Error in thread: %s\n", lua_tostring(L, -1));

--- a/src/work.c
+++ b/src/work.c
@@ -68,6 +68,7 @@ static void luv_work_cb(uv_work_t* req) {
   luv_work_t* work = (luv_work_t*)req->data;
   luv_work_ctx_t* ctx = work->ctx;
   lua_State *L = work->args.L;
+  luv_ctx_t *lctx = luv_context(L);
 
   int top = lua_gettop(L);
 
@@ -93,7 +94,7 @@ static void luv_work_cb(uv_work_t* req) {
 
   if (lua_isfunction(L, -1)) {
     int i = luv_thread_arg_push(L, &work->args, LUVF_THREAD_SIDE_CHILD);
-    i = luv_cfpcall(L, i, LUA_MULTRET, 0);
+    i = lctx->thrd_pcall(L, i, LUA_MULTRET, 0);
     if ( i>=0 ) {
       //clear in main threads, luv_after_work_cb
       i = luv_thread_arg_set(L, &work->rets, top + 1, lua_gettop(L),


### PR DESCRIPTION
If an error occurs in the entry function of a thread, the main thread will also exit if the entry function is not running in protected mode. For software that incorporates `luv`, such as `neovim`, this behavior is fatal. This PR adds `luv_set_thread` so that the thread entry function can be executed in the custom function as well as the `callback`.