### PR TITLE
fix #564, invalid thread argument causes crash.

### DIFF
--- a/src/luv.h
+++ b/src/luv.h
@@ -84,14 +84,21 @@
  */
 typedef int (*luv_CFpcall) (lua_State* L, int nargs, int nresults, int flags);
 
+typedef int (*luv_CFcpcall) (lua_State* L, lua_CFunction func, void* ud, int flags);
+
 /* Default implemention of event callback */
 LUALIB_API int luv_cfpcall(lua_State* L, int nargs, int nresult, int flags);
+
+/* Default implemention of thread entory function */
+LUALIB_API int luv_cfcpcall(lua_State* L, lua_CFunction func, void* ud, int flags);
 
 typedef struct {
   uv_loop_t*   loop;        /* main loop */
   lua_State*   L;           /* main thread,ensure coroutines works */
   luv_CFpcall  cb_pcall;    /* luv event callback function in protected mode */
   luv_CFpcall  thrd_pcall;  /* luv thread function in protected mode*/
+  luv_CFcpcall thrd_cpcall; /* luv thread c function in protected mode*/
+
   int          mode;        /* the mode used to run the loop (-1 if not running) */
 
   void* extra;              /* extra data */
@@ -126,6 +133,13 @@ LUALIB_API void luv_set_callback(lua_State* L, luv_CFpcall pcall);
    (otherwise luv will use the default callback function: luv_cfpcall)
 */
 LUALIB_API void luv_set_thread(lua_State* L, luv_CFpcall pcall);
+
+/* Set or clear an external c routine for luv c thread When using
+ * a custom/external function, this must be called before luaopen_luv
+ * in the function that create the lua_State of the thread
+   (otherwise luv will use the default callback function: luv_cfcpcall)
+*/
+LUALIB_API void luv_set_cthread(lua_State* L, luv_CFcpcall cpcall);
 
 /* This is the main hook to load the library.
    This can be called multiple times in a process as long

--- a/src/private.h
+++ b/src/private.h
@@ -121,6 +121,7 @@ static const char* luv_getmtname(lua_State *L, int idx);
 static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int top, int flags);
 static int luv_thread_arg_push(lua_State* L, luv_thread_arg_t* args, int flags);
 static void luv_thread_arg_clear(lua_State* L, luv_thread_arg_t* args, int flags);
+static int luv_thread_arg_error(lua_State* L);
 
 static luv_acquire_vm acquire_vm_cb = NULL;
 static luv_release_vm release_vm_cb = NULL;

--- a/src/thread.c
+++ b/src/thread.c
@@ -103,11 +103,9 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
       }
       break;
     default:
-      fprintf(stderr, "Error: thread arg not support type '%s' at %d",
-        lua_typename(L, arg->type), i);
-      arg->val.str.base = NULL;
-      arg->val.str.len = 0;
-      break;
+      args->argc = i - idx;
+      return luaL_error(L, "Error: thread arg not support type '%s' at %d",
+        lua_typename(L, arg->type), i - idx + 1);
     }
     i++;
   }

--- a/src/work.c
+++ b/src/work.c
@@ -140,13 +140,14 @@ static void luv_after_work_cb(uv_work_t* req, int status) {
   luv_work_t* work = (luv_work_t*)req->data;
   luv_work_ctx_t* ctx = work->ctx;
   lua_State* L = ctx->L;
+  luv_ctx_t *lctx = luv_context(L);
   int i;
 
   (void)status;
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->after_work_cb);
   i = luv_thread_arg_push(L, &work->rets, LUVF_THREAD_SIDE_MAIN);
-  luv_cfpcall(L, i, 0, 0);
+  lctx->cb_pcall(L, i, 0, 0);
 
   //cache lua_State to reuse
   lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->pool_ref);

--- a/tests/test-work.lua
+++ b/tests/test-work.lua
@@ -112,4 +112,23 @@ return require('lib/tap')(function (test)
     print(2)
     coroutine.resume(co)
   end)
+
+  test("test threadpool with invalid argument", function(print,p,expect,_uv)
+    local work_fn = function() end
+    local after_work_fn = function() end
+    local work_ctx = _uv.new_work(work_fn, after_work_fn)
+
+   local ok,msg = pcall(work_ctx.queue, work_ctx, {})
+   assert(ok==false)
+   assert(msg=="Error: thread arg not support type 'table' at 1")
+  end)
+
+  test("test threadpool with invalid return value", function(print,p,expect,_uv)
+    local work_fn = function() return {} end
+    local after_work_fn = function() end
+    local work_ctx = _uv.new_work(work_fn, after_work_fn)
+
+    assert(work_ctx:queue())
+    assert(not _uv.run())
+  end)
 end)


### PR DESCRIPTION
This is an attempt to fix #564 with a different approach than #565.

Change `luv_work_cb()` to run in protected mode and throw an error in `luv_thread_arg_set()` if an argument of an impermissible type is passed. It's a little more complicated, but I've integrated it into `neovim` and it seems to be working.