### PR TITLE
CI: Use MSVC 2022 and update Lua/Luarocks versions

### DIFF
--- a/.ci/install.bat
+++ b/.ci/install.bat
@@ -181,6 +181,7 @@ if not exist "%LR_ROOT%" (
 		set MSVS_GENERATORS[2015]=Visual Studio 14 2015
 		set MSVS_GENERATORS[2017]=Visual Studio 15 2017
 		set MSVS_GENERATORS[2019]=Visual Studio 16 2019
+		set MSVS_GENERATORS[2022]=Visual Studio 17 2022
 
 		set CMAKE_GENERATOR=!MSVS_GENERATORS[%APPVEYOR_BUILD_WORKER_IMAGE:~14,4%]!
 		:: Starting with MSVC 2019, CMake uses -A option to specify arch rather than Win64 suffix

--- a/.ci/set_compiler_env.bat
+++ b/.ci/set_compiler_env.bat
@@ -11,6 +11,10 @@ set arch=x86
 
 if "%platform%" EQU "x64" ( set arch=x86_amd64 )
 
+if "%COMPILER%"=="2022" (
+	set SET_VS_ENV="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat"
+)
+
 if "%COMPILER%"=="2019" (
 	set SET_VS_ENV="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
 )

--- a/.ci/setup_lua.sh
+++ b/.ci/setup_lua.sh
@@ -67,11 +67,11 @@ else
     curl --silent https://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
     cd lua-5.2.4;
   elif [ "$LUA" == "lua5.3" ]; then
-    curl --silent https://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
-    cd lua-5.3.2;
+    curl --silent https://www.lua.org/ftp/lua-5.3.6.tar.gz | tar xz
+    cd lua-5.3.6;
   elif [ "$LUA" == "lua5.4" ]; then
-    curl --silent https://www.lua.org/ftp/lua-5.4.3.tar.gz | tar xz
-    cd lua-5.4.3;
+    curl --silent https://www.lua.org/ftp/lua-5.4.4.tar.gz | tar xz
+    cd lua-5.4.4;
   fi
 
   # Build Lua without backwards compatibility for testing
@@ -131,7 +131,7 @@ elif [ "$LUA" == "lua5.1" ]; then
 elif [ "$LUA" == "lua5.2" ]; then
   rm -rf lua-5.2.4;
 elif [ "$LUA" == "lua5.3" ]; then
-  rm -rf lua-5.3.2;
+  rm -rf lua-5.3.6;
 elif [ "$LUA" == "lua5.4" ]; then
-  rm -rf lua-5.4.3;
+  rm -rf lua-5.4.4;
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        luarocks_version: [2.4.4, 3.7.0]
+        luarocks_version: [2.4.4, 3.8.0]
         lua_engine: [Lua, LuaJIT]
         include:
           - lua_engine: LuaJIT
@@ -141,7 +141,7 @@ jobs:
     env:
       WITH_LUA_ENGINE: LuaJIT
       LUA: luajit2.1
-      LUAROCKS: 3.7.0
+      LUAROCKS: 3.8.0
     steps:
     - uses: actions/checkout@v2
       with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 image:
   - Visual Studio 2015
-  - Visual Studio 2017
-  - Visual Studio 2019
+  - Visual Studio 2022
 
 platform:
   - x86
@@ -33,14 +32,10 @@ matrix:
       LUAROCKS_VER: 3.4.0
     - platform: x86
       LUAROCKS_VER: 2.3.0
-    # Only test LuaRocks with MSVC 2017
+    # Only test LuaRocks with latest MSVC
     - image: Visual Studio 2015
       LUAROCKS_VER: 3.4.0
     - image: Visual Studio 2015
-      LUAROCKS_VER: 2.3.0
-    - image: Visual Studio 2019
-      LUAROCKS_VER: 3.4.0
-    - image: Visual Studio 2019
       LUAROCKS_VER: 2.3.0
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,32 +11,32 @@ environment:
     - FROM_DEPS: true
 
     # LuaRocks 3.x
-    - LUA_VER: 5.4.1
+    - LUA_VER: 5.4.4
       NOCOMPAT: true  # with compatibility flags disabled.
-      LUAROCKS_VER: 3.4.0
+      LUAROCKS_VER: 3.8.0
     - LJ_VER: 2.1
-      LUAROCKS_VER: 3.4.0
+      LUAROCKS_VER: 3.8.0
 
     # LuaRocks 2.x
-    - LUA_VER: 5.3.2
+    - LUA_VER: 5.3.6
       NOCOMPAT: true  # with compatibility flags disabled.
-      LUAROCKS_VER: 2.3.0
+      LUAROCKS_VER: 2.4.4
     - LJ_VER: 2.1
-      LUAROCKS_VER: 2.3.0
+      LUAROCKS_VER: 2.4.4
 
 matrix:
   fast_finish: true
   exclude:
     # Skip x86 for LuaRocks tests
     - platform: x86
-      LUAROCKS_VER: 3.4.0
+      LUAROCKS_VER: 3.8.0
     - platform: x86
-      LUAROCKS_VER: 2.3.0
+      LUAROCKS_VER: 2.4.4
     # Only test LuaRocks with latest MSVC
     - image: Visual Studio 2015
-      LUAROCKS_VER: 3.4.0
+      LUAROCKS_VER: 3.8.0
     - image: Visual Studio 2015
-      LUAROCKS_VER: 2.3.0
+      LUAROCKS_VER: 2.4.4
 
 cache:
   - c:\lua -> appveyor.yml

--- a/msvcbuild.bat
+++ b/msvcbuild.bat
@@ -1,7 +1,8 @@
 @echo off
 Setlocal EnableDelayedExpansion
 
-if not defined VS set VS=15
+if not defined VS set VS=16
+if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2022" (set VS=17)
 if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (set VS=16)
 if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (set VS=15)
 if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (set VS=14)


### PR DESCRIPTION
This essentially treats MSVC 2015 as the minimum supported version, and updates the Appveyor CI to use MSVC 2022 to do all the Lua/Luarocks tests. From #586:

> I'm thinking about keeping the current 2015 tests, and then moving the rest to just use 2022. That way we can ensure we maintain a minimum supported MSVC (2015) and ensure that we build using the latest version. We won't ensure that the in-between versions will still build properly, but it seems somewhat unlikely that we would introduce problems specific to an in-between version.

Closes #586