### PR TITLE
os_get_passwd: Explicitly compare uid/gid against -1 instead of >= 0

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -373,11 +373,11 @@ static int luv_os_get_passwd(lua_State* L) {
     lua_pushstring(L, pwd.username);
     lua_setfield(L, -2, "username");
   }
-  if (pwd.uid >= 0) {
+  if (pwd.uid != -1) {
     lua_pushinteger(L, pwd.uid);
     lua_setfield(L, -2, "uid");
   }
-  if (pwd.gid >= 0) {
+  if (pwd.gid != -1) {
     lua_pushinteger(L, pwd.gid);
     lua_setfield(L, -2, "gid");
   }


### PR DESCRIPTION
In Libuv 1.44.0, uv_passwd_t.uid/gid was changed to be unsigned, so the >= 0 check would always return true. Changing to compare against -1 explicitly fixes #589 while still maintaining correct functionality when built against previous Libuv versions. Note that with Libuv 1.44.0 and above, this relies on implicitly casting -1 to unsigned long (the type of `uv_passwd_t.uid`/`uv_passwd_t.gid`).

Before (incorrectly including `uid`/`gid`):

```
  { homedir = "C:\\Users\\Ryan", username = "Ryan", uid = 4294967295, gid = 4294967295 }
ok 13 uv.os_get_passwd
```

After (correctly omitting `uid`/`gid`):

```
  { homedir = "C:\\Users\\Ryan", username = "Ryan" }
ok 13 uv.os_get_passwd
```