### PR TITLE
Add `luarocks test` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,13 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        luarocks_version: [2.4.4, 3.8.0]
+        luarocks_version: [3.8.0]
         lua_engine: [Lua, LuaJIT]
         include:
           - lua_engine: LuaJIT
             lua_version: luajit2.1
           - lua_engine: Lua
             lua_version: lua5.4
-          # use 5.3 with Luarocks 2.x
-          - luarocks_version: 2.4.4
-            lua_engine: Lua
-            lua_version: lua5.3
     env:
       # For LuaJIT 2.1, see https://github.com/LuaJIT/LuaJIT/commit/8961a92dd1607108760694af3486b4434602f8be
       MACOSX_DEPLOYMENT_TARGET: 10.12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,26 +17,15 @@ environment:
     - LJ_VER: 2.1
       LUAROCKS_VER: 3.8.0
 
-    # LuaRocks 2.x
-    - LUA_VER: 5.3.6
-      NOCOMPAT: true  # with compatibility flags disabled.
-      LUAROCKS_VER: 2.4.4
-    - LJ_VER: 2.1
-      LUAROCKS_VER: 2.4.4
-
 matrix:
   fast_finish: true
   exclude:
     # Skip x86 for LuaRocks tests
     - platform: x86
       LUAROCKS_VER: 3.8.0
-    - platform: x86
-      LUAROCKS_VER: 2.4.4
     # Only test LuaRocks with latest MSVC
     - image: Visual Studio 2015
       LUAROCKS_VER: 3.8.0
-    - image: Visual Studio 2015
-      LUAROCKS_VER: 2.4.4
 
 cache:
   - c:\lua -> appveyor.yml

--- a/luv-scm-0.rockspec
+++ b/luv-scm-0.rockspec
@@ -3,6 +3,7 @@ version = "scm-0"
 source = {
   url = 'git://github.com/luvit/luv.git'
 }
+rockspec_format = "3.0"
 
 description = {
   summary = "Bare libuv bindings for lua",
@@ -32,4 +33,9 @@ build = {
      LIBDIR="$(LIBDIR)",
      LUADIR="$(LUADIR)",
   },
+}
+
+test = {
+  type = "command",
+  script = "tests/run.lua",
 }

--- a/rockspecs/luv-scm-0.rockspec
+++ b/rockspecs/luv-scm-0.rockspec
@@ -4,6 +4,7 @@ version = "scm-0"
 source = {
   url = 'git://github.com/luvit/luv.git'
 }
+rockspec_format = "3.0"
 
 description = {
   summary = "Bare libuv bindings for lua",
@@ -83,4 +84,9 @@ build = {
       };
     };
   }
+}
+
+test = {
+  type = "command",
+  script = "tests/run.lua",
 }


### PR DESCRIPTION
I think this might drop support for Luarocks earlier than 3.0, but not totally sure. Closes #592