### PR TITLE
opendir and friends: Fix race condition when uv_dir_t pointer doesn't change between allocations

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -2975,14 +2975,14 @@ Copies a file from path to new_path. If the `flags` parameter is omitted, then t
 - `path`: `string`
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
-  - `dir`: `uv_dir_t userdata` or `nil`
+  - `dir`: `luv_dir_t userdata` or `nil`
 - `entries`: `integer` or `nil`
 
 Opens path as a directory stream. Returns a handle that the user can pass to
 `uv.fs_readdir()`. The `entries` parameter defines the maximum number of entries
 that should be returned by each call to `uv.fs_readdir()`.
 
-**Returns (sync version):** `uv_dir_t userdata` or `fail`
+**Returns (sync version):** `luv_dir_t userdata` or `fail`
 
 **Returns (async version):** `uv_fs_t userdata`
 
@@ -2991,12 +2991,12 @@ that should be returned by each call to `uv.fs_readdir()`.
 > method form `dir:readdir([callback])`
 
 **Parameters:**
-- `dir`: `uv_dir_t userdata`
+- `dir`: `luv_dir_t userdata`
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `entries`: `table` or `nil` (see below)
 
-Iterates over the directory stream `uv_dir_t` returned by a successful
+Iterates over the directory stream `luv_dir_t` returned by a successful
 `uv.fs_opendir()` call. A table of data tables is returned where the number
 of entries `n` is equal to or less than the `entries` parameter used in
 the associated `uv.fs_opendir()` call.
@@ -3013,7 +3013,7 @@ the associated `uv.fs_opendir()` call.
 > method form `dir:closedir([callback])`
 
 **Parameters:**
-- `dir`: `uv_dir_t userdata`
+- `dir`: `luv_dir_t userdata`
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `success`: `boolean` or `nil`

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -212,6 +212,17 @@ return require('lib/tap')(function (test)
     assert(uv.fs_opendir('.', opendir_cb, 50))
   end, "1.28.0")
 
+  test("fs.opendir and fs.closedir in a loop", function(print, p, expect, uv)
+    -- Previously, this triggered a GC/closedir race condition
+    -- see https://github.com/luvit/luv/issues/597
+    for _ = 1,1000 do
+      local dir, err = uv.fs_opendir('.', nil, 64)
+      if not err then
+        uv.fs_closedir(dir)
+      end
+    end
+  end, "1.28.0")
+
   test("fs.statfs sync", function (print, p, expect, uv)
     local stat = assert(uv.fs_statfs("."))
     p(stat)


### PR DESCRIPTION
If opendir/closedir was called in a loop, it was possible for the uv_dir_t pointer to always be the same between calls, and due to how we kept track of the 'closed' state of the uv_dir_t by its pointer, this could lead to freeing things twice, or freeing the memory before a readdir call, etc.

Instead, we now use a wrapping luv_dir_t and normal Lua references to keep track of the state

Fixes #597