### PR TITLE
Fix two possible `fs_scandir` segfaults

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -454,9 +454,11 @@ static void luv_fs_cb(uv_fs_t* req) {
           uv_strerror(req->result));                      \
     }                                                     \
     lua_pushstring(L, uv_err_name(req->result));          \
-    luv_cleanup_req(L, data);                             \
-    req->data = NULL;                                     \
-    uv_fs_req_cleanup(req);                               \
+    if(req->fs_type != UV_FS_SCANDIR) {                   \
+      luv_cleanup_req(L, data);                           \
+      req->data = NULL;                                   \
+      uv_fs_req_cleanup(req);                             \
+    }                                                     \
     nargs = 3;                                            \
   }                                                       \
   else if (sync) {                                        \

--- a/src/fs.c
+++ b/src/fs.c
@@ -391,6 +391,11 @@ static int push_fs_result(lua_State* L, uv_fs_t* req) {
 
 static void luv_fs_cb(uv_fs_t* req) {
   luv_req_t* data = (luv_req_t*)req->data;
+  // This can happen if luv_fs_cb is called during loop gc. For example, this can happen
+  // when the async version of fs_scandir is called but the loop is never run before the process exits.
+  //
+  // TODO: A more comprehensive fix for this problem would be related to https://github.com/luvit/luv/issues/437
+  if (data == NULL) return;
   lua_State* L = data->ctx->L;
 
   int nargs = push_fs_result(L, req);

--- a/tests/test-fs.lua
+++ b/tests/test-fs.lua
@@ -125,6 +125,21 @@ return require('lib/tap')(function (test)
     end
   end)
 
+  test("fs.scandir async", function (print, p, expect, uv)
+    assert(uv.fs_scandir('.', function(err, req)
+      assert(not err)
+      local function iter()
+        return uv.fs_scandir_next(req)
+      end
+      for name, ftype in iter do
+        p{name=name, ftype=ftype}
+        assert(name)
+        -- ftype is not available in all filesystems; for example it's
+        -- provided for HFS+ (OSX), NTFS (Windows) but not for ext4 (Linux).
+      end
+    end))
+  end)
+
   -- this test does nothing on its own, but when run with a leak checker,
   -- it will check that the memory allocated by Libuv for req is cleaned up
   -- even if its not iterated fully (or at all)


### PR DESCRIPTION
See commit messages and #603 for more info.

The added test is unrelated to the segfaults, but it's worth making sure that the async version of `fs_scandir` works, which we didn't have a test for previously.