### PR TITLE
Removed output to stderr from poll callback

### DIFF
--- a/src/poll.c
+++ b/src/poll.c
@@ -65,7 +65,6 @@ static void luv_poll_cb(uv_poll_t* handle, int status, int events) {
   const char* evtstr;
 
   if (status < 0) {
-    fprintf(stderr, "%s: %s\n", uv_err_name(status), uv_strerror(status));
     lua_pushstring(L, uv_err_name(status));
   }
   else {


### PR DESCRIPTION
This line has been there for quite a while :) 
I just noticed the log messages when building a libmosquitto wrapper around the poll handle and wondered where it came from.