### PR TITLE
Yet another luajit.cmake unwind detection fix

### DIFF
--- a/deps/luajit.cmake
+++ b/deps/luajit.cmake
@@ -227,7 +227,10 @@ ELSEIF(NOT WIN32)
     execute_process(COMMAND "${CMAKE_C_COMPILER}" -c -x c "${TMPUNWIND_DIR}/tmpunwind.c" -o "${TMPUNWIND_DIR}/tmpunwind.o"
       RESULT_VARIABLE UNWIND_TEST_ERRORED)
     IF(UNWIND_TEST_ERRORED EQUAL 0)
-      file(READ "${TMPUNWIND_DIR}/tmpunwind.o" TMPUNWIND_O)
+      # Use STRINGS here so that CMake doesn't stop reading the file once it hits a NUL character.
+      # Note: STRINGS skips all non-ASCII/binary bytes, but that's okay since we're only checking
+      #       for the presence of some ASCII strings.
+      file(STRINGS "${TMPUNWIND_DIR}/tmpunwind.o" TMPUNWIND_O)
       string(FIND "${TMPUNWIND_O}" "eh_frame" EH_FRAME_FOUND)
       string(FIND "${TMPUNWIND_O}" "__unwind_info" UNWIND_INFO_FOUND)
       IF(EH_FRAME_FOUND GREATER -1 OR UNWIND_INFO_FOUND GREATER -1)


### PR DESCRIPTION
For reference, this is the logic we're trying to copy from LuaJIT's makefile:

https://github.com/LuaJIT/LuaJIT/blob/03080b795aa3496ed62d4a0697c9f4767e7ca7e5/src/Makefile#L339

---

Previously, CMake would only read up to the first NUL or control character (for me that meant it would only read "ELF" from tmpunwind.o). This was making CMake think there was no `eh_frame`/`__unwind_info` string in the file even if there actually was one.

Now, CMake skips binary data in tmpunwind.o and just reads all the ASCII strings from the file, which is fine for what we need to do with it.

This fixes:

    In file included from luv/deps/luajit/src/ljamalg.c:23:
    luv/deps/luajit/src/lj_err.c: In function ‘lj_err_unwind_dwarf’:
    luv/deps/luajit/src/lj_err.c:469:2: error: #error "Broken build system -- only use the provided Makefiles!"
      469 | #error "Broken build system -- only use the provided Makefiles!"
          |  ^~~~~

for me on Linux x86_64 when trying to build Luv (unsure why this wasn't being hit in CI)

---

CMake `MESSAGE` output from when I was debugging:

Before (incorrect, `TMPUNWIND_O` should include more than just `ELF` and `EH_FRAME_FOUND` should not be -1):
```
-- TMPUNWIND_O: ELF
-- EH_FRAME_FOUND: -1
-- UNWIND_INFO_FOUND: -1
```

After (correct, `eh_frame` does exist in tmpunwind.o):
```
-- TMPUNWIND_O: ELF;>;@;@;UH;];GCC: (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0;GNU;zR;x;E;C;K;%;tmpunwind.c;a;_GLOBAL_OFFSET_TABLE_;b;	; ;.symtab;.strtab;.shstrtab;.rela.text;.data;.bss;.comment;.note.GNU-stack;.note.gnu.property;.rela.eh_frame; ;@;@; ;;&;T;,;T;1;0;T;,;:;J; ;b;8;];@;8;; ;	;	;';P;l
-- EH_FRAME_FOUND: 215
-- UNWIND_INFO_FOUND: -1
```