### PR TITLE
cmake: Bump minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if(POLICY CMP0053)
   cmake_policy(SET CMP0053 NEW) # faster evaluation of variable references


### PR DESCRIPTION
Removes the following deprecation warning:

CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

Closes #616, alternative to https://github.com/luvit/luv/pull/583