### PR TITLE
Fix compile warnings.

### DIFF
--- a/src/luv.h
+++ b/src/luv.h
@@ -147,7 +147,7 @@ LUALIB_API void luv_set_cthread(lua_State* L, luv_CFcpcall cpcall);
 */
 LUALIB_API int luaopen_luv (lua_State *L);
 
-typedef lua_State* (*luv_acquire_vm)();
+typedef lua_State* (*luv_acquire_vm)(void);
 typedef void (*luv_release_vm)(lua_State* L);
 LUALIB_API void luv_set_thread_cb(luv_acquire_vm acquire, luv_release_vm release);
 

--- a/src/private.h
+++ b/src/private.h
@@ -111,7 +111,7 @@ static int luv_arg_type_error(lua_State* L, int index, const char* fmt);
 static int luv_optboolean(lua_State*L, int idx, int defaultval);
 
 /* From thread.c */
-static lua_State* luv_thread_acquire_vm();
+static lua_State* luv_thread_acquire_vm(void);
 
 /* From process.c */
 static int luv_parse_signal(lua_State* L, int slot);

--- a/src/thread.c
+++ b/src/thread.c
@@ -24,7 +24,7 @@ typedef struct {
   luv_thread_arg_t args;
 } luv_thread_t;
 
-static lua_State* luv_thread_acquire_vm() {
+static lua_State* luv_thread_acquire_vm(void) {
   lua_State* L = luaL_newstate();
 
   // Add in the lua standard libraries

--- a/src/work.c
+++ b/src/work.c
@@ -127,7 +127,7 @@ static int luv_work_cb(lua_State* L) {
   return LUA_OK;
 }
 
-static lua_State* luv_work_acquire_vm()
+static lua_State* luv_work_acquire_vm(void)
 {
   lua_State* L = uv_key_get(&tls_vmkey);
   if (L == NULL)
@@ -245,7 +245,7 @@ static const luaL_Reg luv_work_ctx_methods[] = {
   {NULL, NULL}
 };
 
-static void luv_key_init_once()
+static void luv_key_init_once(void)
 {
   const char* val;
   int status = uv_key_create(&tls_vmkey);
@@ -287,7 +287,7 @@ static void luv_key_init_once()
   idx_vms = 0;
 }
 
-static void luv_work_cleanup()
+static void luv_work_cleanup(void)
 {
   unsigned int i;
 


### PR DESCRIPTION
Fixed several compile warnings regarding Wshadow and Wstrict-prototypes.

luv/src/fs.c:431:14: warning: declaration of ‘data’ shadows a previous local [-Wshadow]
luv/src/private.h:114:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]

Signed-off-by: Xu Xingliang <xuxingliang@xiaomi.com>