### PR TITLE
[docs] Correct parameter typed as uv_fs_event_t

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -2433,7 +2433,7 @@ it.
 > method form `fs_poll:start(path, interval, callback)`
 
 **Parameters:**
-- `fs_event`: `uv_fs_event_t userdata`
+- `fs_poll`: `uv_fs_poll_t userdata`
 - `path`: `string`
 - `interval`: `integer`
 - `callback`: `callable`


### PR DESCRIPTION
I believe this should be a `poll` not an `event`.