### PR TITLE
doc: update for new_thread note

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -3271,7 +3271,8 @@ provided. Currently accepted `option` fields are `stack_size`.
 
 **Returns:** `luv_thread_t userdata` or `fail`
 
-**Note:** unsafe, please make sure the thread end of life before the Lua state close.
+**Note:** unsafe, please make sure the thread end of life before it is released
+by Lua state close or garbage collection.
 
 ### `uv.thread_equal(thread, other_thread)`
 


### PR DESCRIPTION
There seems to be a problem if the `luv_thread_t userdata` is released before the thread terminates. I have confirmed that the thread entry function may not be executed because `thd->code` was released by `gc` as shown below by the debugger. I have not been successful in creating a test case. An example of a segmentation fault in `luv_thread_arg_clear`, possibly due to this issue, has been reported in the neovim issue(neovim/neovim/issues/22694).

#### test.lua
```lua
local uv = require'luv'

uv.new_thread(function()
  print('Hello')
end)
collectgarbage('collect')

-- wait for thread to finish
uv.sleep(3000)
```

```
> gdb luajit
…
>>> break luv_thread_gc
…
>>> commands
>p "call luv_thread_gc"
>cont
>end
>>> break luv_thread_cb
…
>>> commands
>call sleep(1)
>p "call luv_thread_cb"
>p ((luv_thread_t*)varg)->code
>p ((luv_thread_t*)varg)->len
>cont
>end
>>> run /home/erw7/test.lua
…
Thread 1 "luajit" hit Breakpoint 1, luv_thread_gc (L=0x7fffff3f0380) at ../src/thread.c:253
253     static int luv_thread_gc(lua_State* L) {
$1 = "call luv_thread_gc"
…
Thread 2 "luajit" hit Breakpoint 2, luv_thread_cb (varg=0x7fffff40d178) at ../src/thread.c:269
269     static void luv_thread_cb(void* varg) {
$2 = 0
$3 = "call luv_thread_cb"
$4 = 0x0
$5 = 0
…
```