### PR TITLE
thread_setaffinity: Allow `affinity` param to have a length less than `cpumask_size()`

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -3299,8 +3299,9 @@ equivalent to the `__eq` metamethod.
 Sets the specified thread's affinity setting. `affinity` must be an array-like
 table where each of the keys correspond to a CPU number and the values are
 booleans that represent whether the `thread` should be eligible to run on that
-CPU. The length of the `affinity` table must be greater than or equal to
-`uv.cpumask_size()`. If `get_old_affinity` is `true`, the previous affinity
+CPU. If the length of the `affinity` table is not greater than or equal to
+`uv.cpumask_size()`, any CPU numbers missing from the table will have their
+affinity set to `false`. If `get_old_affinity` is `true`, the previous affinity
 settings for the `thread` will be returned. Otherwise, `true` is returned after
 a successful call.
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -417,8 +417,11 @@ static int luv_thread_setaffinity(lua_State* L) {
     return luv_error(L, min_mask_size);
   }
   int mask_size = lua_rawlen(L, 2);
+  // If the provided table's length is not at least min_mask_size,
+  // we'll use the min_mask_size and fill in any missing values with
+  // false.
   if (mask_size < min_mask_size) {
-    return luaL_argerror(L, 2, lua_pushfstring(L, "cpumask size must be >= %d (from cpumask_size()), got %d", min_mask_size, mask_size));
+    mask_size = min_mask_size;
   }
   char* cpumask = malloc(mask_size);
   for (int i = 0; i < mask_size; i++) {


### PR DESCRIPTION
Instead of enforcing that the table length is `>= cpumask_size()`, any missing CPU numbers get assigned an affinity of `false`. This makes this API a bit more user-friendly, since users no longer have to initialize a table of length `cpumask_size()` before setting the particular  affinities they actually want.

As an example, before this commit, you'd have to do something like:

    local affinity = {}
    for i=1,uv.cpumask_size() do
      affinity[i] = false
    end
    affinity[3] = true
    affinity[5] = true

But after this commit, this table:

    local affinity = { [3] = true, [5] = true }

will now be accepted and all the missing keys up to `uv_cpumask_size()` will be treated as `false` in the `thread_setaffinity` call.