### PR TITLE
docs: make process_kill signum arg optional

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1279,7 +1279,7 @@ When the child process exits, `on_exit` is called with an exit code and signal.
 
 **Parameters:**
 - `process`: `uv_process_t userdata`
-- `signum`: `integer` or `string`
+- `signum`: `integer` or `string` or `nil` (default: `sigterm`)
 
 Sends the specified signal to the given process handle. Check the documentation
 on `uv_signal_t` for signal support, specially on Windows.


### PR DESCRIPTION
In Libuv, [uv_process_kill](https://docs.libuv.org/en/v1.x/process.html#c.uv_process_kill) takes a process and a signum, where the signum is required. In Luv although, in luv_parse_signal, if the input is not an integer and not a string, the default value of SIGTERM is used.

Effectively making signum an optional argument with the default string value `sigterm`.