### PR TITLE
docs: add missing uv.os_unsetenv() parameter

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -3771,7 +3771,12 @@ Sets the environmental variable specified by `name` with the string `value`.
 
 **Warning:** This function is not thread safe.
 
-### `uv.os_unsetenv()`
+### `uv.os_unsetenv(name)`
+
+**Parameters:**
+- `name`: `string`
+
+Unsets the environmental variable specified by `name`.
 
 **Returns:** `boolean` or `fail`
 


### PR DESCRIPTION
uv.os_unsetenv takes a name parameter.

📝 code
https://github.com/luvit/luv/blob/8ca04df069eb837a725af1f02e4b5a59bb1ae7ef/src/misc.c#L498-L506
