### PR TITLE
docs: make uv.kill's signum optional

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1290,7 +1290,7 @@ on `uv_signal_t` for signal support, specially on Windows.
 
 **Parameters:**
 - `pid`: `integer`
-- `signum`: `integer` or `string`
+- `signum`: `integer` or `string` or `nil` (default: `sigterm`)
 
 Sends the specified signal to the given PID. Check the documentation on
 `uv_signal_t` for signal support, specially on Windows.


### PR DESCRIPTION
same as https://github.com/luvit/luv/pull/666/ for the same reasons.

See https://github.com/luvit/luv/blob/9e3c2320149884e5d809e9391f8580bb5f67bcdf/src/process.c#L319-L324