### PR TITLE
docs: Correct uv.spawn `options.args` docs about the first argument

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1235,10 +1235,11 @@ end)
 
 The `options` table accepts the following fields:
 
-  - `options.args` - Command line arguments as a list of string. The first
-  string should be the path to the program. On Windows, this uses CreateProcess
-  which concatenates the arguments into a string. This can cause some strange
-  errors. (See `options.verbatim` below for Windows.)
+  - `options.args` - Command line arguments as a list of strings. The first
+  string should *not* be the path to the program, since that is already
+  provided via `path`. On Windows, this uses CreateProcess which concatenates
+  the arguments into a string. This can cause some strange errors
+  (see `options.verbatim` below for Windows).
   - `options.stdio` - Set the file descriptors that will be made available to
   the child process. The convention is that the first entries are stdin, stdout,
   and stderr. (**Note**: On Windows, file descriptors after the third are


### PR DESCRIPTION
This was left over from the libuv docs, but the luv bindings handle this differently and `options.args` should *only* include the command arguments, not the command name itself.

See https://github.com/luvit/luv/issues/673#issuecomment-1703780666

Example from our tests:

https://github.com/luvit/luv/blob/dcd1a1cad5b05634a7691402d6ca2f214fb4ae76/tests/test-process.lua#L14-L31