### PR TITLE
Remove redundant CMake policy change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
-if(POLICY CMP0053)
-  cmake_policy(SET CMP0053 NEW) # faster evaluation of variable references
-endif()
-
 project (luv C ASM)
 
 set(LUV_VERSION_MAJOR 1)


### PR DESCRIPTION
Default since CMake 3.1