### PR TITLE
docs: new_async callback is not optional

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -922,14 +922,14 @@ end)
 async:send()
 ```
 
-### `uv.new_async([callback])`
+### `uv.new_async(callback)`
 
 **Parameters:**
-- `callback`: `callable` or `nil`
+- `callback`: `callable`
   - `...`: `threadargs` passed to/from `uv.async_send(async, ...)`
 
 Creates and initializes a new `uv_async_t`. Returns the Lua userdata wrapping
-it. A `nil` callback is allowed.
+it.
 
 **Returns:** `uv_async_t userdata` or `fail`
 


### PR DESCRIPTION
From what I can see, the callback argument is not optional and can't be nil.

See https://github.com/luvit/luv/blob/master/src/async.c#L38.

I can't be 100% sure that the docs are wrong here and not the code itself for not allowing optional callbacks, but I can't see why would anyone need to create an async handle with no callback as that is counterintuitive.

