### PR TITLE
docs: most new_handle methods won't return fail

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -779,7 +779,7 @@ end)
 Creates and initializes a new `uv_prepare_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_prepare_t userdata` or `fail`
+**Returns:** `uv_prepare_t userdata`
 
 ### `uv.prepare_start(prepare, callback)`
 
@@ -825,7 +825,7 @@ end)
 Creates and initializes a new `uv_check_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_check_t userdata` or `fail`
+**Returns:** `uv_check_t userdata`
 
 ### `uv.check_start(check, callback)`
 
@@ -878,7 +878,7 @@ end)
 Creates and initializes a new `uv_idle_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_idle_t userdata` or `fail`
+**Returns:** `uv_idle_t userdata`
 
 ### `uv.idle_start(idle, callback)`
 
@@ -1783,7 +1783,7 @@ Creates and initializes a new `uv_pipe_t`. Returns the Lua userdata wrapping
 it. The `ipc` argument is a boolean to indicate if this pipe will be used for
 handle passing between processes.
 
-**Returns:** `uv_pipe_t userdata` or `fail`
+**Returns:** `uv_pipe_t userdata`
 
 ### `uv.pipe_open(pipe, fd)`
 
@@ -2431,7 +2431,7 @@ handle uses the best backend for the job on each platform.
 Creates and initializes a new `uv_fs_event_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_fs_event_t userdata` or `fail`
+**Returns:** `uv_fs_event_t userdata`
 
 ### `uv.fs_event_start(fs_event, path, flags, callback)`
 
@@ -2487,7 +2487,7 @@ they can work on file systems where fs event handles can't.
 Creates and initializes a new `uv_fs_poll_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_fs_poll_t userdata` or `fail`
+**Returns:** `uv_fs_poll_t userdata`
 
 ### `uv.fs_poll_start(fs_poll, path, interval, callback)`
 
@@ -3330,7 +3330,7 @@ a Lua function or a string containing Lua code or bytecode dumped from a functio
 are passed to the `entry` function and an optional `options` table may be
 provided. Currently accepted `option` fields are `stack_size`.
 
-**Returns:** `luv_thread_t userdata` or `fail`
+**Returns:** `luv_thread_t userdata`
 
 **Note:** unsafe, please make sure the thread end of life before Lua state close.
 

--- a/docs.md
+++ b/docs.md
@@ -3330,7 +3330,7 @@ a Lua function or a string containing Lua code or bytecode dumped from a functio
 are passed to the `entry` function and an optional `options` table may be
 provided. Currently accepted `option` fields are `stack_size`.
 
-**Returns:** `luv_thread_t userdata`
+**Returns:** `luv_thread_t userdata` or `fail`
 
 **Note:** unsafe, please make sure the thread end of life before Lua state close.
 

--- a/docs.md
+++ b/docs.md
@@ -2431,7 +2431,7 @@ handle uses the best backend for the job on each platform.
 Creates and initializes a new `uv_fs_event_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_fs_event_t userdata`
+**Returns:** `uv_fs_event_t userdata` or `fail`
 
 ### `uv.fs_event_start(fs_event, path, flags, callback)`
 

--- a/docs.md
+++ b/docs.md
@@ -1783,7 +1783,7 @@ Creates and initializes a new `uv_pipe_t`. Returns the Lua userdata wrapping
 it. The `ipc` argument is a boolean to indicate if this pipe will be used for
 handle passing between processes.
 
-**Returns:** `uv_pipe_t userdata`
+**Returns:** `uv_pipe_t userdata` or `fail`
 
 ### `uv.pipe_open(pipe, fd)`
 
@@ -2487,7 +2487,7 @@ they can work on file systems where fs event handles can't.
 Creates and initializes a new `uv_fs_poll_t`. Returns the Lua userdata wrapping
 it.
 
-**Returns:** `uv_fs_poll_t userdata`
+**Returns:** `uv_fs_poll_t userdata` or `fail`
 
 ### `uv.fs_poll_start(fs_poll, path, interval, callback)`
 


### PR DESCRIPTION
Since I've used this docs to generate my luvit-meta definitions, which will complain about not using `assert` on methods that could return `nil` (on failure), I've had to investigate into things like `local pipe = uv.new_pipe()` not using an assert in the examples.
And it appears like it and the methods listed below will never return a failure tuple when initializing a new handle.  Even though the docs here explicitly imply otherwise as the return type is `handle_type or fail`.

Here are the details and how I came to the conclusion that each one of the methods patched don't return an error:

- `new_prepare` and `new_check` and `new_idle`: 
    - on Luv side:
       - in Luv those are `luv_new_prepare` etc.
       - they make a call to `uv_prepare_init` (and `uv_check_init` and `uv_idle_init`).
       - a failure is returned if the return of this call is `ret < 0`.
       
    - on libuv side:
       - the `uv_name_init` methods are defined in [loop-watcher.c](https://github.com/libuv/libuv/blob/master/src/loop-watcher.c) using a macro.
       - in `int uv_##name##_init` [we see that](https://github.com/libuv/libuv/blob/master/src/loop-watcher.c#L26C6-L26C6) the return is always `0` therefor never fails.
 
 
The following have been initially included in this PR, they have been reverted now. See the comments below.

> 
> - `new_pipe`:
>    - on Luv side:
>       - in Luv it is defined as `luv_new_pipe` in [pipe.c](https://github.com/luvit/luv/blob/master/src/pipe.c#L25).
>       - `uv_pipe_init` is called, if it returns a value less than 0 it is failure.
>       
>    - on libuv side:
>       - the `uv_pipe_init` is defined in [unix/pipe.c](https://github.com/libuv/libuv/blob/master/src/unix/pipe.c#L33).
>       - the return is always 0, therefor never fails.
>  
>  - `new_fs_event`:
>     - on the Luv side:
>        - it is `luv_new_fs_event` defined in [fs_event.c](https://github.com/luvit/luv/blob/master/src/fs_event.c#L26).
>        - returns [failure when](https://github.com/luvit/luv/blob/master/src/fs_event.c#L29) `uv_fs_event_init` returns a value less than 0.
> 
>     - on libuv side:
>         - `uv_fs_event_init` is defined per platform. take for example [unix/linux-inotify.c](https://github.com/libuv/libuv/blob/master/src/unix/linux.c#L2487) (this is weirdly enough called just `linux.c` nowadays in libuv, but that is unrelated).
>         - always returns 0 therefor never fails.
>  
>  - `new_fs_poll`:
>      - on Luv side:
>          - it is `luv_new_fs_poll` defined in [fs_poll.c](https://github.com/luvit/luv/blob/master/src/fs_poll.c#L26).
>          - `uv_fs_poll_init` is called, if it returns a value less than 0 it returns failure.
>          
>      - on libuv side:
>          - `uv_fs_poll_init` is defined in [fs-poll.c](https://github.com/libuv/libuv/blob/master/src/fs-poll.c#L59).
>          - the return is always 0 therefor it never fails.
>       