### PR TITLE
docs: typo in a table field name

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1960,7 +1960,7 @@ Bind the pipe to a file path (Unix) or a name (Windows).
 `Flags`:
 
 - If `type(flags)` is `number`, it must be `0` or `uv.constants.PIPE_NO_TRUNCATE`.
-- If `type(flags)` is `table`, it must be `{}` or `{ no_trunate = true|false }`.
+- If `type(flags)` is `table`, it must be `{}` or `{ no_truncate = true|false }`.
 - If `type(flags)` is `nil`, it use default value `0`.
 - Returns `EINVAL` for unsupported flags without performing the bind operation.
 
@@ -1991,7 +1991,7 @@ Connect to the Unix domain socket or the named pipe.
 `Flags`:
 
 - If `type(flags)` is `number`, it must be `0` or `uv.constants.PIPE_NO_TRUNCATE`.
-- If `type(flags)` is `table`, it must be `{}` or `{ no_trunate = true|false }`.
+- If `type(flags)` is `table`, it must be `{}` or `{ no_truncate = true|false }`.
 - If `type(flags)` is `nil`, it use default value `0`.
 - Returns `EINVAL` for unsupported flags without performing the bind operation.
 


### PR DESCRIPTION
the field name is `no_truncate` not `no_trunate`, it is correctly defined in the code.

I think the `true|false` format is also inconsistent, it will make things harder when generating the docs, should simply be something like `{ no_truncate: boolean }`, or the more consistent
```md
`flags`:
   `no_truncate`: `boolean`
```
update:
There is also a new `**Note**` format that was introduced with https://github.com/luvit/luv/commit/8e2f3066f9e999affa668f1dabe633e418b0cefd.
But maybe I will tackle those later when I progress with https://github.com/Bilal2453/luv-docgen.