### PR TITLE
Annotate .gitmodules with branch and tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,18 @@
 [submodule "libuv"]
 	path = deps/libuv
 	url = https://github.com/libuv/libuv.git
+	branch = v1.x
+	tag = v1.48.0
 [submodule "luajit"]
 	path = deps/luajit
 	url = https://github.com/LuaJIT/LuaJIT.git
+	branch = v2.1
 [submodule "lua"]
 	path = deps/lua
 	url = https://github.com/lua/lua
+	branch = v5.4
 [submodule "lua-compat-5.3"]
 	path = deps/lua-compat-5.3
 	url = https://github.com/keplerproject/lua-compat-5.3.git
+	branch = master
+	tag = v0.12

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,6 @@
 	path = deps/libuv
 	url = https://github.com/libuv/libuv.git
 	branch = v1.x
-	tag = v1.48.0
 [submodule "luajit"]
 	path = deps/luajit
 	url = https://github.com/LuaJIT/LuaJIT.git
@@ -10,8 +9,7 @@
 [submodule "lua"]
 	path = deps/lua
 	url = https://github.com/lua/lua
-	branch = master
-	tag = v5.4.6
+	branch = v5.4
 [submodule "lua-compat-5.3"]
 	path = deps/lua-compat-5.3
 	url = https://github.com/keplerproject/lua-compat-5.3.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,9 @@
 [submodule "lua"]
 	path = deps/lua
 	url = https://github.com/lua/lua
-	branch = v5.4
+	branch = master
+	tag = v5.4.6
 [submodule "lua-compat-5.3"]
 	path = deps/lua-compat-5.3
 	url = https://github.com/keplerproject/lua-compat-5.3.git
 	branch = master
-	tag = v0.12


### PR DESCRIPTION
I'm working on an experiment to make submodules easier to work with.  Part of that is annotating .gitmodules with information to make it so tools can automatically update dependencies.

The `branch` field is actually supported already by [upstream git itself](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-set-branch-b--branchltbranchgt--ltpathgt).

The `tag` field is my invention and my tool may be using it to do semver updates based on the tag name and available upstream tags.

I'm not convinced the tag needs to be documented here since the commit hash is already in git and it possible to map that back to tags.  I've removed `tag` from the PR for now till I'm convinced it needs to be in the file.