### PR TITLE
docs: Clarify types for mode arg in some filesystem functions

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -2666,7 +2666,7 @@ If `offset` is nil or omitted, it will default to `-1`, which indicates 'use and
 
 **Parameters:**
 - `path`: `string`
-- `mode`: `integer` (octal representation of `chmod(1)` mode)
+- `mode`: `integer` (octal `chmod(1)` mode, e.g. `tonumber('755', 8)`)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `success`: `boolean` or `nil`
@@ -2914,7 +2914,7 @@ Returns `true` or `false` indicating access permission.
 
 **Parameters:**
 - `path`: `string`
-- `mode`: `integer` (octal representation of `chmod(1)` mode)
+- `mode`: `integer` (octal `chmod(1)` mode, e.g. `tonumber('644', 8)`)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `success`: `boolean` or `nil`

--- a/docs.md
+++ b/docs.md
@@ -2591,7 +2591,7 @@ Equivalent to `close(2)`.
 **Parameters:**
 - `path`: `string`
 - `flags`: `string` or `integer`
-- `mode`: `integer` (octal representation of `chmod(1)` mode)
+- `mode`: `integer` (octal `chmod(1)` mode, e.g. `tonumber('644', 8)`)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `fd`: `integer` or `nil`

--- a/docs.md
+++ b/docs.md
@@ -2591,7 +2591,7 @@ Equivalent to `close(2)`.
 **Parameters:**
 - `path`: `string`
 - `flags`: `string` or `integer`
-- `mode`: `integer`
+- `mode`: `integer` (octal representation of `chmod(1)` mode)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `fd`: `integer` or `nil`
@@ -2666,7 +2666,7 @@ If `offset` is nil or omitted, it will default to `-1`, which indicates 'use and
 
 **Parameters:**
 - `path`: `string`
-- `mode`: `integer`
+- `mode`: `integer` (octal representation of `chmod(1)` mode)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `success`: `boolean` or `nil`
@@ -2897,7 +2897,7 @@ Limited equivalent to `sendfile(2)`. Returns the number of bytes written.
 
 **Parameters:**
 - `path`: `string`
-- `mode`: `integer`
+- `mode`: `string`  (a combination of the `'r'`, `'w'` and `'x'` characters denoting the symbolic mode as per `chmod(1)`)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `permission`: `boolean` or `nil`
@@ -2914,7 +2914,7 @@ Returns `true` or `false` indicating access permission.
 
 **Parameters:**
 - `path`: `string`
-- `mode`: `integer`
+- `mode`: `integer` (octal representation of `chmod(1)` mode)
 - `callback`: `callable` (async version) or `nil` (sync version)
   - `err`: `nil` or `string`
   - `success`: `boolean` or `nil`


### PR DESCRIPTION
Some libuv filesystem functions expect the numeric `mode` argument to be an octal representation of the equivalent `chmod(1)` mode. This is potentially surprising behaviour to anyone who hasn't used either `libuv` or `glibc` from C. The documentation for e.g. `fs_mkdir` in libuv defers to `mkdir(2)` which defers to `mode_t(3)` which only says "It is an integer type". Furthermore, `fs_access` uses a different `mode` type, validated using
[luv_check_amode](https://github.com/luvit/luv/blob/7233e6dea92498a244feb51b790c1ba51e8abbff/src/fs.c#L184), which can accept strings ("symbolic mode" in `chmod(1)`). I chose not to mention that this one still technically accepts an integer because I have no idea about the restrictions of said integer.