### PR TITLE
Support passing tables and closures to new threads

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -73,7 +73,7 @@ used here to facilitate documenting consistent behavior:
   metamethod
 - `buffer`: a `string` or a sequential `table` of `string`s
 - `threadargs`: variable arguments (`...`) of type `nil`, `boolean`, `number`,
-  `string`, or `userdata`, numbers of argument limited to 9.
+  `string`, `userdata`, `function`, or `table`, numbers of argument limited to 9.
 
 ## Contents
 

--- a/src/lthreadpool.h
+++ b/src/lthreadpool.h
@@ -21,8 +21,10 @@
 
 #define LUV_THREAD_MAXNUM_ARG 9
 
+typedef struct luv_table luv_table_t;
+
 typedef struct {
-  // support basic lua type LUA_TNIL, LUA_TBOOLEAN, LUA_TNUMBER, LUA_TSTRING
+  // support lua types of LUA_TNIL, LUA_TBOOLEAN, LUA_TNUMBER, LUA_TSTRING, LUA_TTABLE
   // and support uv_handle_t userdata
   int type;
   union
@@ -34,13 +36,30 @@ typedef struct {
       size_t len;
     } str;
     struct {
+      const void* code;
+      size_t len;
+    } function;
+    struct {
       const void* data;
       size_t size;
       const char* metaname;
     } udata;
+    luv_table_t* table;
   } val;
   int ref[2];          // ref of string or userdata
 } luv_val_t;
+
+typedef struct {
+  luv_val_t key;
+  luv_val_t value;
+} luv_table_pair_t;
+
+// A Lua table including its metatable.
+struct luv_table {
+  luv_table_t* metatable; // NULL if no metatable
+  size_t len; // number of pairs in the table
+  luv_table_pair_t pairs[];
+};
 
 typedef struct {
   int argc;

--- a/src/lthreadpool.h
+++ b/src/lthreadpool.h
@@ -22,8 +22,9 @@
 #define LUV_THREAD_MAXNUM_ARG 9
 
 typedef struct luv_table luv_table_t;
+typedef struct luv_val luv_val_t;
 
-typedef struct {
+struct luv_val {
   // support lua types of LUA_TNIL, LUA_TBOOLEAN, LUA_TNUMBER, LUA_TSTRING, LUA_TTABLE
   // and support uv_handle_t userdata
   int type;
@@ -36,18 +37,21 @@ typedef struct {
       size_t len;
     } str;
     struct {
-      const void* code;
-      size_t len;
-    } function;
-    struct {
       const void* data;
       size_t size;
       const char* metaname;
     } udata;
+    struct {
+      // if `code_len` == 0 then `code` is a pointer to C function.
+      size_t code_len;
+      const void* code;
+      size_t upvalues_len;
+      luv_val_t* upvalues;
+    } function;
     luv_table_t* table;
   } val;
   int ref[2];          // ref of string or userdata
-} luv_val_t;
+};
 
 typedef struct {
   luv_val_t key;

--- a/tests/test-work.lua
+++ b/tests/test-work.lua
@@ -113,22 +113,21 @@ return require('lib/tap')(function (test)
     coroutine.resume(co)
   end)
 
-  test("test threadpool with invalid argument", function(print,p,expect,_uv)
+  test("test threadpool with table argument", function(print,p,expect,_uv)
     local work_fn = function() end
     local after_work_fn = function() end
     local work_ctx = _uv.new_work(work_fn, after_work_fn)
 
-   local ok,msg = pcall(work_ctx.queue, work_ctx, {})
-   assert(ok==false)
-   assert(msg=="Error: thread arg not support type 'table' at 1")
+   local ok = pcall(work_ctx.queue, work_ctx, {})
+   assert(ok)
   end)
 
-  test("test threadpool with invalid return value", function(print,p,expect,_uv)
+  test("test threadpool with table return value", function(print,p,expect,_uv)
     local work_fn = function() return {} end
     local after_work_fn = function() end
     local work_ctx = _uv.new_work(work_fn, after_work_fn)
 
-    assert(work_ctx:queue())
-    assert(not _uv.run())
+   local ok = pcall(work_ctx.queue, work_ctx, {})
+   assert(ok)
   end)
 end)


### PR DESCRIPTION
Hi luvit team, first thank you for this great project! Luv makes it possible for calling libuv functions in Neovim!

In this PR I changed `thread_arg_*` functions to support `table` and `function` types to `new_thread()`, `queue_work()` and `async_send()` functions.

Althrough in some feature requesting issues you said that not supporting tables is intentional (I can't find the exact reply anymore), I believe it's a very important feature to have. It will unlock possibilities like multi-threaded Neovim plugins, off-loading some CPU intensive work to a thread pool. I sincerely invite you to re-think this feature.

I mainly translated Neovim's [deepcopy()](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/shared.lua#L13-L43) function to C. It uses a cache table to properly support reused table fields.

The function type supports upvalues. Supporting functions is needed because it allows Lua OOP values to be passed to new threads.

Testing: I added test and passed valgrind, and I've tested this branch in Neovim. However not tested in Lua versions other than LuaJIT.