### PR TITLE
Avoid SEGFAULTs in uv.walk when processing invalid handles

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -95,7 +95,7 @@ static void luv_walk_cb(uv_handle_t* handle, void* arg) {
 
   // Sanity check
   // Most invalid values are large and refs are small, 0x1000000 is arbitrary.
-  assert(data && data->ref < 0x1000000);
+  if(!data || data->ref >= 0x1000000) return;
 
   lua_pushvalue(L, 1);           // Copy the function
   luv_find_handle(L, data);      // Get the userdata


### PR DESCRIPTION
Much ado for nothing, but this does resolve #721. Let me know if you prefer a different solution!