### PR TITLE
Protect async send from misuse

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -55,8 +55,13 @@ static int luv_async_send(lua_State* L) {
   int ret;
   uv_async_t* handle = luv_check_async(L, 1);
   luv_thread_arg_t* arg = (luv_thread_arg_t *)((luv_handle_t*) handle->data)->extra;
-
-  luv_thread_arg_set(L, arg, 2, lua_gettop(L), LUVF_THREAD_MODE_ASYNC|LUVF_THREAD_SIDE_CHILD);
+  int top = lua_gettop(L);
+  if (arg->flags != 0 && // if not the first call
+      (arg->argc != 0 || top != 1)) // if arguments have been or are used
+  {
+    return luaL_error(L, "Invalid multiple calls with arguments");
+  }
+  luv_thread_arg_set(L, arg, 2, top, LUVF_THREAD_MODE_ASYNC|LUVF_THREAD_SIDE_CHILD);
   ret = uv_async_send(handle);
   luv_thread_arg_clear(L, arg, LUVF_THREAD_SIDE_CHILD);
   return luv_result(L, ret);


### PR DESCRIPTION
This is a proposal to mitigate the async send issues, see #505
⚠️This is a breaking change as some misuse could work but with unexpected behavior.

Using arguments when calling async send is helpful but does not match the libuv implementation that will coalesce calls.
Properly supporting multiple calls is a lot of work and may not be interesting for luv.

I propose to restrict the usage by allowing arguments only when async send is used just once.
It is still possible to call multiple times async send without arguments which is the libuv API.
It seems to me to be a simple but necessary fix.

Another option would be to use a lock to be able to change the arguments and free the not yet received ones, but there will be no guaranty on which arguments will be effectively received. This option is only interesting to avoid breaking existing misuse.