### PR TITLE
Support Lua integer in thread and async arguments

### DIFF
--- a/src/lthreadpool.h
+++ b/src/lthreadpool.h
@@ -27,7 +27,13 @@ typedef struct {
   int type;
   union
   {
-    lua_Number num;
+    struct {
+      int isinteger;
+      union {
+        lua_Number n;
+        lua_Integer i;
+      } value;
+    } num;
     int boolean;
     struct {
       const char* base;

--- a/src/thread.c
+++ b/src/thread.c
@@ -83,7 +83,12 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
       arg->val.boolean = lua_toboolean(L, i);
       break;
     case LUA_TNUMBER:
-      arg->val.num = lua_tonumber(L, i);
+      arg->val.num.isinteger = lua_isinteger(L, i);
+      if (arg->val.num.isinteger) {
+        arg->val.num.value.i = lua_tointeger(L, i);
+      } else {
+        arg->val.num.value.n = lua_tonumber(L, i);
+      }
       break;
     case LUA_TSTRING:
       if (async)
@@ -181,7 +186,11 @@ static int luv_thread_arg_push(lua_State* L, luv_thread_arg_t* args, int flags) 
       lua_pushboolean(L, arg->val.boolean);
       break;
     case LUA_TNUMBER:
-      lua_pushnumber(L, arg->val.num);
+      if (arg->val.num.isinteger) {
+        lua_pushinteger(L, arg->val.num.value.i);
+      } else {
+        lua_pushnumber(L, arg->val.num.value.n);
+      }
       break;
     case LUA_TSTRING:
       lua_pushlstring(L, arg->val.str.base, arg->val.str.len);

--- a/tests/test-thread.lua
+++ b/tests/test-thread.lua
@@ -62,14 +62,16 @@ return require('lib/tap')(function (test)
     local delay = 100
     uv.update_time()
     local before = uv.now()
-    local args = {delay, 'string', nil, false, 5, "helloworld"}
+    local args = {delay, 'string', nil, false, 5, 3.14, "helloworld"}
     local unpack = unpack or table.unpack
-    uv.new_thread({stack_size=0}, function(delay,s,null,bool,five,hw)
+    uv.new_thread({stack_size=0}, function(delay,s,null,bool,five,pi,hw)
       assert(type(delay) == "number")
       assert(type(s) == "string")
       assert(null == nil)
       assert(bool == false)
       assert(five == 5)
+      assert(math.type(five) == 'integer')
+      assert(pi == 3.14)
       assert(hw == 'helloworld')
       require('luv').sleep(delay)
     end, unpack(args)):join()


### PR DESCRIPTION
When passing integers, available since Lua 5.3, as thread or async arguments, the value pushed in the thread or async function is a float.

This change adds the integer flavor to the existing Lua number argument.