### PR TITLE
Use a special metatable for thread userdata arguments

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -897,6 +897,7 @@ LUALIB_API int luaopen_luv (lua_State* L) {
 #endif
   luv_thread_init(L);
   luv_work_init(L);
+  luv_async_init(L);
 
   luv_constants(L);
   lua_setfield(L, -2, "constants");

--- a/tests/test-async.lua
+++ b/tests/test-async.lua
@@ -1,7 +1,6 @@
 return require('lib/tap')(function (test)
 
   test("test pass async between threads", function(p, p, expect, uv)
-    local before = os.time()
     local async
     async = uv.new_async(expect(function (a,b,c)
       p('in async notify callback')
@@ -11,22 +10,41 @@ return require('lib/tap')(function (test)
       assert(c==250)
       uv.close(async)
     end))
-    local args = {500, 'string', nil, false, 5, "helloworld",async}
-    local unpack = unpack or table.unpack
-    uv.new_thread(function(num,s,null,bool,five,hw,asy)
+    uv.new_thread(function(asy)
       local uv = require'luv'
-      assert(type(num) == "number")
-      assert(type(s) == "string")
-      assert(null == nil)
-      assert(bool == false)
-      assert(five == 5)
-      assert(hw == 'helloworld')
       assert(type(asy)=='userdata')
       assert(uv.async_send(asy,'a',true,250)==0)
-      uv.sleep(1000)
-    end, unpack(args)):join()
-    local elapsed = (os.time() - before) * 1000
-    assert(elapsed >= 1000, "elapsed should be at least delay ")
+      uv.run()
+    end, async):join()
+  end)
+
+  test("test pass back async between threads", function(p, p, expect, uv)
+    local rasync
+    local async
+    async = uv.new_async(expect(function (a)
+      uv.close(async)
+      p('in async notify callback')
+      p(a)
+      assert(type(a)=='userdata')
+      assert(uv.async_send(a,'a',true,250)==0)
+      rasync = a
+    end))
+    local t = uv.new_thread(function(asy)
+      local uv = require'luv'
+      assert(type(asy)=='userdata', 'bad aync type')
+      local as
+      as = uv.new_async(function (a,b,c)
+        uv.close(as)
+        assert(a=='a', 'bad string')
+        assert(b==true, 'bad boolean')
+        assert(c==250, 'bad number')
+      end)
+      assert(uv.async_send(asy,as)==0)
+      uv.run()
+    end, async)
+    uv.run()
+    t:join()
+    assert(rasync, 'thread async not received')
   end)
 
 end)


### PR DESCRIPTION
This is a proposal for handling thread and async userdata arguments.

The current implementation copies the userdata block of raw memory, sets the same metatable then removes it after the callback.
This implementation requires the userdata usage to be thread-safe and not used after the callback.

As far as I see the main use case for passing userdata consists in passing async to the thread callback.
It is not possible to check if a userdata is thread-safe.
The userdata cannot be used after the callback which is fine for thread but not for async.

This change consists in letting the caller opt-in to pass the metatable by providing a dedicated metatable suffixed `_ref`.
Such metatable is provided for `uv_async` with no close nor gc.
There is still a major issue as the async could be garbage collected on the main side.

Another option would be to forbid all userdata arguments except async or not setting the metatable at all.