### PR TITLE
Fix a misleading skip message in test-tty.lua

### DIFF
--- a/tests/test-tty.lua
+++ b/tests/test-tty.lua
@@ -1,12 +1,12 @@
 -- come from https://github.com/libuv/libuv/blob/v1.x/test/test-tty.c
-local _, ffi = pcall(require, 'ffi')
-if not ffi then
-  print('skip, without luajit ffi')
+local success, ffi = pcall(require, 'ffi')
+if not success then
+  print('Skipped test-tty: LuaJIT FFI not found')
   return
 end
 
 if not (ffi.os == "Linux" or ffi.os == "OSX") then
-  print('skip, not on linux or macos')
+  print('Skipped test-tty: Not on Linux or macOS')
   return
 end
 


### PR DESCRIPTION
While looking into the Valgrind/assertion failure, I noticed the following message being output:

> skip, not on linux or macos

I found this puzzling as I'm actually on Linux. The message also appears in CI workflows using the `ubuntu-latest` image.

A brief investigation yielded that the [early exit in test-tty.lua](https://github.com/luvit/luv/blob/9299a4b211537a82719ada35c045891089eb8b33/tests/test-tty.lua#L2-L11) is faulty; it expects the second `pcall` return value to be `nil`, but in this case it's the typical `module 'ffi' not found` error (that is, a `string` value).

The `ffi` module isn't found because the valgrind workflow only builds PUC Lua and uses that to run the tests. Seeing how there's conditional logic/`cdef` uses here, it may be worth running valgrind + tests with both engines just in case?
