### PR TITLE
Fix async arguments

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -908,6 +908,7 @@ LUALIB_API int luaopen_luv (lua_State* L) {
 
   luv_req_init(L);
   luv_handle_init(L);
+  luv_async_init(L);
 #if LUV_UV_VERSION_GEQ(1, 28, 0)
   luv_dir_init(L);
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -66,7 +66,11 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
   int i;
   int side = LUVF_THREAD_SIDE(flags);
   int async = LUVF_THREAD_ASYNC(flags);
-
+  /*
+   * thread works by reference.
+   * async works by copy, a use case consists in sending just before the thread ends,
+   * it results that the callback will be called after the thread/async life.
+   */
   idx = idx > 0 ? idx : 1;
   i = idx;
   args->flags = flags;
@@ -91,11 +95,12 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
       }
       break;
     case LUA_TSTRING:
-      if (async)
-      {
-        const char* p = lua_tolstring(L, i, &arg->val.str.len);
-        arg->val.str.base = malloc(arg->val.str.len);
-        memcpy((void*)arg->val.str.base, p, arg->val.str.len);
+      if (async) {
+        size_t l = 0;
+        const char* p = lua_tolstring(L, i, &l);
+        void* b = malloc(l + 1);
+        arg->val.str.base = memcpy((void*)b, p, l + 1);
+        arg->val.str.len = l;
       } else {
         arg->val.str.base = lua_tolstring(L, i, &arg->val.str.len);
         lua_pushvalue(L, i);
@@ -103,13 +108,27 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
       }
       break;
     case LUA_TUSERDATA:
-      arg->val.udata.data = lua_topointer(L, i);
-      arg->val.udata.size = lua_rawlen(L, i);
-      arg->val.udata.metaname = luv_getmtname(L, i);
-
-      if (arg->val.udata.size) {
-        lua_pushvalue(L, i);
-        arg->ref[side] = luaL_ref(L, LUA_REGISTRYINDEX);
+      {
+        const void* p = lua_topointer(L, i);
+        size_t l = lua_rawlen(L, i);
+        const char* mtname = luv_getmtname(L, i);
+        if (async) {
+          if (l > 0) {
+            void* b = malloc(l);
+            p = (const void*)memcpy(b, p, l);
+          }
+          if (mtname != NULL) {
+            size_t ml = strlen(mtname) + 1;
+            char* b = malloc(ml);
+            mtname = (const void*)memcpy(b, mtname, ml);
+          }
+        } else {
+          lua_pushvalue(L, i);
+          arg->ref[side] = luaL_ref(L, LUA_REGISTRYINDEX);
+        }
+        arg->val.udata.data = p;
+        arg->val.udata.size = l;
+        arg->val.udata.metaname = mtname;
       }
       break;
     default:
@@ -127,42 +146,45 @@ static int luv_thread_arg_set(lua_State* L, luv_thread_arg_t* args, int idx, int
 static void luv_thread_arg_clear(lua_State* L, luv_thread_arg_t* args, int flags) {
   int i;
   int side = LUVF_THREAD_SIDE(flags);
-  int set = LUVF_THREAD_SIDE(args->flags);
+  int setside = LUVF_THREAD_SIDE(args->flags);
   int async = LUVF_THREAD_ASYNC(args->flags);
-
-  if (args->argc == 0)
-    return;
-
+  /*
+   * clear is safe to be called multiple times, values are set to LUA_NOREF or NULL, argc is preserved.
+   * thread unrefs per side.
+   * async frees values on the first calling side.
+   */
   for (i = 0; i < args->argc; i++) {
     luv_val_t* arg = args->argv + i;
     switch (arg->type) {
     case LUA_TSTRING:
-      if (arg->ref[side] != LUA_NOREF)
-      {
+      if (arg->ref[side] != LUA_NOREF) {
         luaL_unref(L, LUA_REGISTRYINDEX, arg->ref[side]);
         arg->ref[side] = LUA_NOREF;
-      } else {
-        if(async && set!=side)
-        {
-          free((void*)arg->val.str.base);
-          arg->val.str.base = NULL;
-          arg->val.str.len = 0;
-        }
+      }
+      if (async) {
+        free((void*)arg->val.str.base);
+        arg->val.str.base = NULL;
       }
       break;
     case LUA_TUSERDATA:
-      if (arg->ref[side]!=LUA_NOREF)
-      {
-        if (side != set)
-        {
+      if (arg->ref[side] != LUA_NOREF) {
+        if (side != setside) {
           // avoid custom gc
           lua_rawgeti(L, LUA_REGISTRYINDEX, arg->ref[side]);
           lua_pushnil(L);
           lua_setmetatable(L, -2);
-          lua_pop(L, -1);
+          lua_pop(L, 1);
         }
         luaL_unref(L, LUA_REGISTRYINDEX, arg->ref[side]);
         arg->ref[side] = LUA_NOREF;
+      }
+      if (async) {
+        if (arg->val.udata.size > 0) {
+          free((void*)arg->val.udata.data);
+          arg->val.udata.data = NULL;
+        }
+        free((void*)arg->val.udata.metaname);
+        arg->val.udata.metaname = NULL;
       }
       break;
     default:
@@ -171,7 +193,6 @@ static void luv_thread_arg_clear(lua_State* L, luv_thread_arg_t* args, int flags
   }
 }
 
-// called only in thread
 static int luv_thread_arg_push(lua_State* L, luv_thread_arg_t* args, int flags) {
   int i = 0;
   int side = LUVF_THREAD_SIDE(flags);
@@ -196,18 +217,16 @@ static int luv_thread_arg_push(lua_State* L, luv_thread_arg_t* args, int flags) 
       lua_pushlstring(L, arg->val.str.base, arg->val.str.len);
       break;
     case LUA_TUSERDATA:
-      if (arg->val.udata.size)
-      {
+      if (arg->val.udata.size > 0) {
         char *p = lua_newuserdata(L, arg->val.udata.size);
         memcpy(p, arg->val.udata.data, arg->val.udata.size);
-        if (arg->val.udata.metaname)
-        {
+        if (arg->val.udata.metaname != NULL) {
           luaL_getmetatable(L, arg->val.udata.metaname);
           lua_setmetatable(L, -2);
         }
         lua_pushvalue(L, -1);
         arg->ref[side] = luaL_ref(L, LUA_REGISTRYINDEX);
-      }else{
+      } else {
         lua_pushlightuserdata(L, (void*)arg->val.udata.data);
       }
       break;
@@ -306,9 +325,11 @@ static void luv_thread_cb(void* varg) {
 
 static void luv_thread_notify_close_cb(uv_handle_t *handle) {
   luv_thread_t *thread = handle->data;
-  if (thread->handle != 0)
-    uv_thread_join(&thread->handle);
-
+  uv_thread_t uvt = thread->handle;
+  if (uvt != 0) {
+    thread->handle = 0;
+    uv_thread_join(&uvt);
+  }
   luaL_unref(thread->L, LUA_REGISTRYINDEX, thread->ref);
   thread->ref = LUA_NOREF;
   thread->L = NULL;
@@ -494,9 +515,12 @@ static int luv_thread_setpriority(lua_State* L) {
 
 static int luv_thread_join(lua_State* L) {
   luv_thread_t* tid = luv_check_thread(L, 1);
-  int ret = uv_thread_join(&tid->handle);
-  if (ret < 0) return luv_error(L, ret);
-  tid->handle = 0;
+  uv_thread_t uvt = tid->handle;
+  if (uvt != 0) {
+    tid->handle = 0;
+    int ret = uv_thread_join(&uvt);
+    if (ret < 0) return luv_error(L, ret);
+  }
   lua_pushboolean(L, 1);
   return 1;
 }

--- a/tests/test-async.lua
+++ b/tests/test-async.lua
@@ -1,32 +1,104 @@
 return require('lib/tap')(function (test)
 
   test("test pass async between threads", function(p, p, expect, uv)
-    local before = os.time()
     local async
-    async = uv.new_async(expect(function (a,b,c)
+    async = uv.new_async(expect(function (s, b, i, n, u)
       p('in async notify callback')
-      p(a,b,c)
-      assert(a=='a')
-      assert(b==true)
-      assert(c==250)
+      p(s, b, i, n, u)
+      assert(s=='a', 'bad string')
+      assert(b==true, 'bad boolean')
+      assert(i==250, 'bad integer')
+      assert(n==3.14, 'bad number')
+      assert(type(u)=='userdata', 'bad userdata')
       uv.close(async)
     end))
-    local args = {500, 'string', nil, false, 5, "helloworld",async}
-    local unpack = unpack or table.unpack
-    uv.new_thread(function(num,s,null,bool,five,hw,asy)
-      local uv = require'luv'
-      assert(type(num) == "number")
-      assert(type(s) == "string")
-      assert(null == nil)
-      assert(bool == false)
-      assert(five == 5)
-      assert(hw == 'helloworld')
+    uv.new_thread(function(asy)
       assert(type(asy)=='userdata')
-      assert(uv.async_send(asy,'a',true,250)==0)
-      uv.sleep(1000)
-    end, unpack(args)):join()
-    local elapsed = (os.time() - before) * 1000
-    assert(elapsed >= 1000, "elapsed should be at least delay ")
+      assert(asy:send('a', true, 250, 3.14, io.stderr)==0)
+      require('luv').sleep(10)
+    end, async):join()
+  end)
+
+  test("test async multiple send", function(p, p, expect, uv)
+    local async
+    async = uv.new_async(expect(function (v)
+      p('in async notify callback')
+      assert(v=='ok')
+      async:close()
+    end))
+    uv.new_thread(function(asy)
+      assert(type(asy)=='userdata')
+      assert(asy:send('not ok')==0) -- will be ignored but its ok
+      assert(asy:send('ok')==0)
+      require('luv').sleep(10)
+    end, async):join()
+  end)
+
+  test("test async send from same thread", function(p, p, expect, uv)
+    local async
+    async = uv.new_async(expect(function (v)
+      p('in async notify callback')
+      assert(v=='ok')
+      async:close()
+    end))
+    assert(async:send('not ok')==0) -- will be ignored but its ok
+    assert(async:send('ok')==0)
+    uv.run()
+  end)
+
+  test("test async send during callback", function(p, p, expect, uv)
+    local async
+    async = uv.new_async(expect(function (d, v)
+      p('in async notify callback', d, v)
+      assert(v=='ok')
+      if d > 0 then
+        uv.sleep(d)
+      else
+        async:close()
+      end
+    end, 2))
+    local t = uv.new_thread(function(asy)
+      local uv = require('luv')
+      assert(type(asy)=='userdata')
+      assert(asy:send(100, 'ok')==0)
+      uv.sleep(10) -- let async callback starts
+      assert(asy:send(0, 'ok')==0)
+      uv.sleep(10)
+    end, async)
+    uv.run()
+    t:join()
+  end)
+
+  test("test pass back async between threads", function(p, p, expect, uv)
+    local async
+    async = uv.new_async(expect(function (asy)
+      async:close()
+      p('in async notify callback')
+      assert(type(asy)=='userdata')
+      assert(debug.getmetatable(asy))
+      assert(asy:send('Hi\0', true, 250)==0) -- only working inside callback
+      local timer = uv.new_timer()
+      timer:start(10, 0, expect(function()
+        timer:close()
+        p('timeout')
+        assert(not debug.getmetatable(asy)) -- outside callback the userdata loose its metatable
+      end))
+    end))
+    local t = uv.new_thread(function(asy)
+      local uv = require('luv')
+      assert(type(asy)=='userdata', 'bad aync type')
+      local as
+      as = uv.new_async(function (s, b, i)
+        as:close()
+        assert(s=='Hi\0', 'bad string')
+        assert(b==true, 'bad boolean')
+        assert(i==250, 'bad integer')
+      end)
+      assert(asy:send(as)==0)
+      uv.run()
+    end, async)
+    uv.run()
+    t:join()
   end)
 
 end)


### PR DESCRIPTION
Protect async `send()` arguments using a mutex.
Use copy for async arguments rather than Lua reference.
Clear arguments in callback and before sending rather than after.
Keep existing and possibly weird behavior.

Fixes #505

This fix is rather unsatisfying and could be enhanced later.
A correct later fix would be:
* to remove async send arguments and assume that luv, as libuv, may combine multiple calls to async `send()` or
* to use a FIFO queue between async `send()` and callback ensuring the callback is executed one per send.

But both require a modification on how luv behave.