### PR TITLE
fix: prevent calling uv.run while already running.

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -32,6 +32,11 @@ static const char *const luv_runmodes[] = {
 static int luv_run(lua_State* L) {
   int mode = luaL_checkoption(L, 1, "default", luv_runmodes);
   luv_ctx_t* ctx = luv_context(L);
+  if (ctx->mode != -1) {
+    lua_pushnil(L);
+    lua_pushstring(L, "loop already running");
+    return 2;
+  }
   ctx->mode = mode;
   int ret = uv_run(ctx->loop, (uv_run_mode)mode);
   ctx->mode = -1;


### PR DESCRIPTION
As documented, uv_run is NOT re-entrant and this
prevents this from happening by returning fail.

Each lua state has its own uv loop, so the only
way for this to happen is for uv.run to be called
from a libuv callback.