### PR TITLE
move luv_work_cleanup into loop gc

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -838,6 +838,11 @@ static int loop_gc(lua_State *L) {
   while (uv_loop_close(loop)) {
     uv_run(loop, UV_RUN_DEFAULT);
   }
+  /* do cleanup in main thread */
+  lua_getglobal(L, "_THREAD");
+  if (lua_isnil(L, -1))
+    luv_work_cleanup();
+  lua_pop(L, 1);
   return 0;
 }
 
@@ -885,12 +890,6 @@ LUALIB_API int luaopen_luv (lua_State* L) {
     if (ret < 0) {
       return luaL_error(L, "%s: %s\n", uv_err_name(ret), uv_strerror(ret));
     }
-
-    /* do cleanup in main thread */
-    lua_getglobal(L, "_THREAD");
-    if (lua_isnil(L, -1))
-      atexit(luv_work_cleanup);
-    lua_pop(L, 1);
   }
   // pcall is NULL, luv use default callback routine
   if (ctx->cb_pcall==NULL) {

--- a/src/test.c
+++ b/src/test.c
@@ -63,7 +63,7 @@ static lua_State *vm_acquire(uv_loop_t* loop) {
 static void vm_release(lua_State* L) { lua_close(L); }
 
 
-static lua_State* luv_thread_acquire_vm() {
+static lua_State* luv_thread_acquire_vm(void) {
   lua_State* L = vm_acquire(NULL);  /* create state */
 
   lua_pushboolean(L, 1);


### PR DESCRIPTION
atexit may be called after luv is unloaded and will segfault.

Associated https://github.com/luvit/luv/issues/712