### PR TITLE
new luv_cleanup to handle cleanup of non-gc resources

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -815,6 +815,11 @@ LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop) {
   ctx->mode = -1;
 }
 
+// Clean up luv resources when using an external loop, after the loop has stopped.
+LUALIB_API void luv_cleanup(void) {
+  luv_work_cleanup();
+}
+
 // Set an external event callback routine, before luaopen_luv
 LUALIB_API void luv_set_callback(lua_State* L, luv_CFpcall pcall) {
   luv_ctx_t* ctx = luv_context(L);
@@ -855,7 +860,7 @@ static int loop_gc(lua_State *L) {
   /* do cleanup in main thread */
   lua_getglobal(L, "_THREAD");
   if (lua_isnil(L, -1))
-    luv_work_cleanup();
+    luv_cleanup();
   lua_pop(L, 1);
   return 0;
 }

--- a/src/luv.h
+++ b/src/luv.h
@@ -127,6 +127,13 @@ LUALIB_API uv_loop_t* luv_loop(lua_State* L);
 */
 LUALIB_API void luv_set_loop(lua_State* L, uv_loop_t* loop);
 
+/* Free all non-garbaged-collected resources allocated by luv. This function
+   must be called when using an external uv_loop_t, it is called during garbage
+   collection of the Lua userdata for the uv_loop_t otherwise. This must only
+   be called after all lua_States using luv have stopped their uv_loop_t.
+*/
+LUALIB_API void luv_cleanup(void);
+
 /* Set or clear an external c routine for luv event callback
    When using a custom/external function, this must be called before luaopen_luv
    (otherwise luv will use the default callback function: luv_cfpcall)


### PR DESCRIPTION
This adds a solution to the problem of cleaning up luv resources when using an external uv_loop_t in cases such as neovim introduced by moving work cleanup into the `__gc` for the loop.

This function is necessary for external loops to not leak memory when luv is no longer in use.

Likely solution for #754.

Associated with the merging of this PR a note should be placed on the previous release about the introduction of this issue and that the solution is to update and use this function.