### PR TITLE
feat: add binding for semaphore to test synchronization

### DIFF
--- a/docs/docs.lua
+++ b/docs/docs.lua
@@ -365,6 +365,7 @@ local types = {
   luv_dir_t = cls('userdata'),
   luv_work_ctx_t = cls('userdata'),
   luv_thread_t = cls('userdata'),
+  luv_sem_t = cls('userdata'),
 
   threadargs = union('number', 'boolean', 'string', 'userdata'),
 
@@ -4181,6 +4182,63 @@ local doc = {
           params = {
             { name = 'msec', type = 'integer' },
           },
+        },
+        {
+          name = 'new_sem',
+          desc = [[
+            Creates a new semaphore with the specified initial value. A semaphore is safe to
+            share across threads. It represents an unsigned integer value that can incremented
+            and decremented atomically but any attempt to make it negative will "wait" until
+            the value can be decremented by another thread incrementing it.
+
+            The initial value must be a non-negative integer.
+          ]],
+          params = {
+            { name = 'value', type = opt_int },
+          },
+          returns = ret_or_fail('luv_sem_t', 'sem'),
+          notes = {
+            [[A semaphore must be shared between threads, any `uv.sem_wait()` on a single thread that blocks will deadlock.]],
+          },
+        },
+        {
+          name = 'sem_post',
+          method_form = 'sem:post()',
+          desc = [[
+            Increments (unlocks) a semaphore, if the semaphore's value consequently becomes
+            greater than zero then another thread blocked in a sem_wait call will be woken
+            and proceed to decrement the semaphore.
+          ]],
+          params = {
+            { name = 'sem', type = 'luv_sem_t' },
+          },
+        },
+        {
+          name = 'sem_wait',
+          method_form = 'sem:wait()',
+          desc = [[
+              Decrements (locks) a semaphore, if the semaphore's value is greater than zero
+              then the value is decremented and the call returns immediately. If the semaphore's
+              value is zero then the call blocks until the semaphore's value rises above zero or
+              the call is interrupted by a signal.
+          ]],
+          params = {
+            { name = 'sem', type = 'luv_sem_t' },
+          },
+        },
+        {
+          name = 'sem_trywait',
+          method_form = 'sem:trywait()',
+          desc = [[
+              The same as `uv.sem_wait()` but returns immediately if the semaphore is not available.
+
+              If the semaphore's value was decremented then `true` is returned, otherwise the semaphore
+              has a value of zero and `false` is returned.
+          ]],
+          params = {
+            { name = 'sem', type = 'luv_sem_t' },
+          },
+          returns = 'boolean',
         },
       },
     },

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3850,6 +3850,63 @@ Pauses the thread in which this is called for a number of milliseconds.
 
 **Returns:** Nothing.
 
+### `uv.new_sem([value])`
+
+**Parameters:**
+- `value`: `integer` or `nil`
+
+Creates a new semaphore with the specified initial value. A semaphore is safe to
+share across threads. It represents an unsigned integer value that can incremented
+and decremented atomically but any attempt to make it negative will "wait" until
+the value can be decremented by another thread incrementing it.
+
+The initial value must be a non-negative integer.
+
+**Returns:** `luv_sem_t userdata` or `fail`
+
+**Note**: A semaphore must be shared between threads, any `uv.sem_wait()` on a single thread that blocks will deadlock.
+
+### `uv.sem_post(sem)`
+
+> method form `sem:post()`
+
+**Parameters:**
+- `sem`: `luv_sem_t userdata`
+
+Increments (unlocks) a semaphore, if the semaphore's value consequently becomes
+greater than zero then another thread blocked in a sem_wait call will be woken
+and proceed to decrement the semaphore.
+
+**Returns:** Nothing.
+
+### `uv.sem_wait(sem)`
+
+> method form `sem:wait()`
+
+**Parameters:**
+- `sem`: `luv_sem_t userdata`
+
+Decrements (locks) a semaphore, if the semaphore's value is greater than zero
+then the value is decremented and the call returns immediately. If the semaphore's
+value is zero then the call blocks until the semaphore's value rises above zero or
+the call is interrupted by a signal.
+
+**Returns:** Nothing.
+
+### `uv.sem_trywait(sem)`
+
+> method form `sem:trywait()`
+
+**Parameters:**
+- `sem`: `luv_sem_t userdata`
+
+The same as `uv.sem_wait()` but returns immediately if the semaphore is not available.
+
+If the semaphore's value was decremented then `true` is returned, otherwise the semaphore
+has a value of zero and `false` is returned.
+
+**Returns:** `boolean`
+
 ## Miscellaneous utilities
 
 [Miscellaneous utilities]: #miscellaneous-utilities

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -3946,6 +3946,62 @@ function luv_thread_t:getname() end
 --- @param msec integer
 function uv.sleep(msec) end
 
+--- Creates a new semaphore with the specified initial value. A semaphore is safe to
+--- share across threads. It represents an unsigned integer value that can incremented
+--- and decremented atomically but any attempt to make it negative will "wait" until
+--- the value can be decremented by another thread incrementing it.
+---
+--- The initial value must be a non-negative integer.
+--- **Note**:
+--- A semaphore must be shared between threads, any `uv.sem_wait()` on a single thread that blocks will deadlock.
+--- @param value integer?
+--- @return uv.luv_sem_t? sem
+--- @return string? err
+--- @return uv.error_name? err_name
+function uv.new_sem(value) end
+
+--- Increments (unlocks) a semaphore, if the semaphore's value consequently becomes
+--- greater than zero then another thread blocked in a sem_wait call will be woken
+--- and proceed to decrement the semaphore.
+--- @param sem uv.luv_sem_t
+function uv.sem_post(sem) end
+
+--- @class uv.luv_sem_t : userdata
+local luv_sem_t = {}
+
+--- Increments (unlocks) a semaphore, if the semaphore's value consequently becomes
+--- greater than zero then another thread blocked in a sem_wait call will be woken
+--- and proceed to decrement the semaphore.
+function luv_sem_t:post() end
+
+--- Decrements (locks) a semaphore, if the semaphore's value is greater than zero
+--- then the value is decremented and the call returns immediately. If the semaphore's
+--- value is zero then the call blocks until the semaphore's value rises above zero or
+--- the call is interrupted by a signal.
+--- @param sem uv.luv_sem_t
+function uv.sem_wait(sem) end
+
+--- Decrements (locks) a semaphore, if the semaphore's value is greater than zero
+--- then the value is decremented and the call returns immediately. If the semaphore's
+--- value is zero then the call blocks until the semaphore's value rises above zero or
+--- the call is interrupted by a signal.
+function luv_sem_t:wait() end
+
+--- The same as `uv.sem_wait()` but returns immediately if the semaphore is not available.
+---
+--- If the semaphore's value was decremented then `true` is returned, otherwise the semaphore
+--- has a value of zero and `false` is returned.
+--- @param sem uv.luv_sem_t
+--- @return boolean
+function uv.sem_trywait(sem) end
+
+--- The same as `uv.sem_wait()` but returns immediately if the semaphore is not available.
+---
+--- If the semaphore's value was decremented then `true` is returned, otherwise the semaphore
+--- has a value of zero and `false` is returned.
+--- @return boolean
+function luv_sem_t:trywait() end
+
 
 --- # Miscellaneous utilities
 

--- a/src/luv.c
+++ b/src/luv.c
@@ -43,6 +43,7 @@
 #include "signal.c"
 #include "stream.c"
 #include "tcp.c"
+#include "synch.c"
 #include "thread.c"
 #include "timer.c"
 #include "tty.c"
@@ -407,6 +408,12 @@ static const luaL_Reg luv_functions[] = {
   {"thread_getname", luv_thread_getname},
   {"thread_setname", luv_thread_setname},
 #endif
+
+  // synch.c
+  {"new_sem", luv_new_sem},
+  {"sem_post", luv_sem_post},
+  {"sem_wait", luv_sem_wait},
+  {"sem_trywait", luv_sem_trywait},
 
 #if LUV_UV_VERSION_GEQ(1, 49, 0)
   {"utf16_length_as_wtf8", luv_utf16_length_as_wtf8},
@@ -920,6 +927,7 @@ LUALIB_API int luaopen_luv (lua_State* L) {
   luv_dir_init(L);
 #endif
   luv_thread_init(L);
+  luv_synch_init(L);
   luv_work_init(L);
 
   luv_constants(L);

--- a/src/synch.c
+++ b/src/synch.c
@@ -1,0 +1,83 @@
+/*
+*  Copyright 2014 The Luvit Authors. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*/
+#include "private.h"
+
+static uv_sem_t* luv_check_sem(lua_State* L, int index) {
+  return (uv_sem_t*) luv_checkudata(L, index, "uv_sem");
+}
+
+static int luv_new_sem(lua_State* L) {
+  int value = luaL_optinteger(L, 1, 0);
+  if (value < 0) {
+    return luaL_argerror(L, 1, "value must be >= 0");
+  }
+
+  uv_sem_t *sem = (uv_sem_t*) luv_newuserdata(L, sizeof(uv_sem_t));
+  luaL_getmetatable(L, "uv_sem");
+  lua_setmetatable(L, -2);
+
+  int ret = uv_sem_init(sem, value);
+  if (ret < 0) {
+    lua_pop(L, 1);
+    return luv_error(L, ret);
+  }
+  return 1;
+}
+
+static int luv_sem_gc(lua_State* L) {
+  uv_sem_t* sem = luv_check_sem(L, 1);
+
+  uv_sem_destroy(sem);
+  free(sem);
+  return 0;
+}
+
+static int luv_sem_post(lua_State* L) {
+  uv_sem_t* sem = luv_check_sem(L, 1);
+  uv_sem_post(sem);
+  return 0;
+}
+
+static int luv_sem_wait(lua_State* L) {
+  uv_sem_t* sem = luv_check_sem(L, 1);
+  uv_sem_wait(sem);
+  return 0;
+}
+
+static int luv_sem_trywait(lua_State* L) {
+  uv_sem_t* sem = luv_check_sem(L, 1);
+  int ret = uv_sem_trywait(sem);
+  lua_pushboolean(L, ret == 0);
+  return 1;
+}
+
+static const luaL_Reg luv_sem_methods[] = {
+  {"post", luv_sem_post},
+  {"wait", luv_sem_wait},
+  {"trywait", luv_sem_trywait},
+  {NULL, NULL}
+};
+
+static void luv_synch_init(lua_State* L) {
+  luaL_newmetatable(L, "uv_sem");
+  lua_pushcfunction(L, luv_sem_gc);
+  lua_setfield(L, -2, "__gc");
+  lua_newtable(L);
+  luaL_setfuncs(L, luv_sem_methods, 0);
+  lua_setfield(L, -2, "__index");
+  lua_pop(L, 1);
+}

--- a/src/thread.c
+++ b/src/thread.c
@@ -54,11 +54,11 @@ static void luv_thread_release_vm(lua_State* L) {
 
 static const char* luv_getmtname(lua_State *L, int idx) {
   const char* name;
-  lua_getmetatable(L, idx);
-  lua_pushstring(L, "__name");
-  lua_rawget(L, -2);
-  name = lua_tostring(L, -1);
-  lua_pop(L, 2);
+  if (lua_getmetatable(L, idx)) {
+    lua_getfield(L, -1, "__name");
+    name = lua_tostring(L, -1);
+    lua_pop(L, 2);
+  }
   return name;
 }
 

--- a/tests/test-thread.lua
+++ b/tests/test-thread.lua
@@ -167,12 +167,16 @@ return require('lib/tap')(function (test)
     assert(type(uv.constants.THREAD_PRIORITY_BELOW_NORMAL)=='number')
     assert(type(uv.constants.THREAD_PRIORITY_LOWEST)=='number')
 
-    local thread = uv.new_thread(function()
+    local sem = uv.new_sem(0)
+    local thread = uv.new_thread(function(sem)
       local _uv = require('luv')
       local self = _uv.thread_self()
+      _uv.sem_wait(sem)
       local priority = assert(self:getpriority())
       print('priority in thread', priority)
-    end)
+    end, sem)
+
+    uv.sleep(100)
 
     local priority = assert(thread:getpriority())
     print('default priority', priority)
@@ -180,6 +184,8 @@ return require('lib/tap')(function (test)
     assert(thread:setpriority(uv.constants.THREAD_PRIORITY_LOWEST))
     priority = assert(thread:getpriority())
     print('priority after change', priority)
+
+    sem:post()
     thread:join()
   end, "1.48.0")
 


### PR DESCRIPTION
Adds a binding to the uv_sem_t interface to allow properly synchronizing thread-related functions across threads.

Fixes #730 