### PR TITLE
docs: document nil callback when needed

### DIFF
--- a/docs/docgen.lua
+++ b/docs/docgen.lua
@@ -538,7 +538,7 @@ do -- meta
   local function sig(func, method)
     local args = {} --- @type string[]
     for i, param in ipairs(func.params or {}) do
-      if not (func.returns_async and param.name == 'callback') and (not method or i > 1) then
+      if not (func.returns_async and param.name == 'callback' and i == #func.params) and (not method or i > 1) then
         args[#args + 1] = id(param.name)
       end
     end
@@ -762,8 +762,9 @@ do -- meta
 
     if func.params then
       for i, param in ipairs(func.params) do
-        if not (func.returns_async and param.name == 'callback') and (not method or i > 1) then
-          out:write('--- @param ', id(param.name), ' ', Meta.ty(param.type))
+        local is_async_callback_param = func.returns_async and param.name == 'callback'
+        if not (is_async_callback_param and i == #func.params) and (not method or i > 1) then
+          out:write('--- @param ', id(param.name), ' ', is_async_callback_param and 'nil' or Meta.ty(param.type))
           if param.desc then
             if param.desc:match('\n') then
               write_comment(out, param.desc)

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -3547,12 +3547,13 @@ function uv.fs_copyfile(path, new_path, flags) end
 --- `uv.fs_readdir()`. The `entries` parameter defines the maximum number of entries
 --- that should be returned by each call to `uv.fs_readdir()`.
 --- @param path string
+--- @param callback nil (async if provided, sync if `nil`)
 --- @param entries integer?
 --- @return uv.luv_dir_t? dir
 --- @return string? err
 --- @return uv.error_name? err_name
 --- @overload fun(path: string, callback: fun(err: string?, dir: uv.luv_dir_t?), entries: integer?): uv.uv_fs_t
-function uv.fs_opendir(path, entries) end
+function uv.fs_opendir(path, callback, entries) end
 
 --- Iterates over the directory stream `luv_dir_t` returned by a successful
 --- `uv.fs_opendir()` call. A table of data tables is returned where the number


### PR DESCRIPTION
Fixes incorrect uv.fs_opendir documentation. It seem to be the only luv function where the optional callback is not at the end of the signature, so the callback param was incorrectly omitted before.