### PR TITLE
Skip udp multicast test when EHOSTUNREACH is returned

### DIFF
--- a/tests/test-udp.lua
+++ b/tests/test-udp.lua
@@ -251,7 +251,10 @@ return require('lib/tap')(function (test)
         -- and for ipv6:
         --  ip6tables --policy OUTPUT DROP
         --  ip6tables -A OUTPUT -s ::1 -j ACCEPT
-        if err == "EPERM" then
+        --
+        -- EHOSTUNREACH was also observed on the macos CI runner
+        -- TODO: Investigate EHOSTUNREACH more: https://github.com/luvit/luv/issues/781
+        if err == "EPERM" or err == "EHOSTUNREACH" then
           print("send to multicast ip was likely denied by firewall, skipping")
           client:close()
           server:close()


### PR DESCRIPTION
This is just meant as a quick fix. It might end up being the correct fix if EHOSTUNREACH means something similar to EPERM on Linux.

See also #781