### PR TITLE
docs: add `os_get_passwd` fail and windows-specific values

### DIFF
--- a/docs/docs.lua
+++ b/docs/docs.lua
@@ -4641,14 +4641,13 @@ local doc = {
           name = 'os_get_passwd',
           desc = [[
             Gets a subset of the password file entry for the current effective uid (not the
-            real uid). On Windows, uid and gid are set to -1 and have no meaning, and shell
-            is NULL.
+            real uid). On Windows, `uid`, `gid`, and `shell` are set to `nil`.
           ]],
           returns = ret_or_fail(
             table({
               { 'username', 'string' },
-              { 'uid', 'integer', nil, "(-1 on Windows)" },
-              { 'gid', 'integer', nil, "(-1 on Windows)" },
+              { 'uid', 'integer?', nil, "(nil on Windows)" },
+              { 'gid', 'integer?', nil, "(nil on Windows)" },
               { 'shell', 'string?', nil, "(nil on Windows)"},
               { 'homedir', 'string' },
             }),

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4318,13 +4318,12 @@ Returns a temporary directory.
 ### `uv.os_get_passwd()`
 
 Gets a subset of the password file entry for the current effective uid (not the
-real uid). On Windows, uid and gid are set to -1 and have no meaning, and shell
-is NULL.
+real uid). On Windows, `uid`, `gid`, and `shell` are set to `nil`.
 
 **Returns:** `table` or `fail`
 - `username`: `string`
-- `uid`: `integer` (-1 on Windows)
-- `gid`: `integer` (-1 on Windows)
+- `uid`: `integer?` (nil on Windows)
+- `gid`: `integer?` (nil on Windows)
 - `shell`: `string?` (nil on Windows)
 - `homedir`: `string`
 

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -4369,19 +4369,18 @@ function uv.os_tmpdir() end
 --- @class uv.os_get_passwd.passwd
 --- @field username string
 ---
---- (-1 on Windows)
---- @field uid integer
+--- (nil on Windows)
+--- @field uid integer?
 ---
---- (-1 on Windows)
---- @field gid integer
+--- (nil on Windows)
+--- @field gid integer?
 ---
 --- (nil on Windows)
 --- @field shell string?
 --- @field homedir string
 
 --- Gets a subset of the password file entry for the current effective uid (not the
---- real uid). On Windows, uid and gid are set to -1 and have no meaning, and shell
---- is NULL.
+--- real uid). On Windows, `uid`, `gid`, and `shell` are set to `nil`.
 --- @return uv.os_get_passwd.passwd? passwd
 --- @return string? err
 --- @return uv.error_name? err_name


### PR DESCRIPTION
Documents that `os_get_passwd` can fail (as found in https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1921), as well as the Windows-specific values for the fields in the return table as mentioned in https://docs.libuv.org/en/v1.x/misc.html#c.uv_os_get_passwd