### PR TITLE
Allow using WITH_SHARED_LIBUV with rockspec build

### DIFF
--- a/luv-scm-0.rockspec
+++ b/luv-scm-0.rockspec
@@ -32,6 +32,7 @@ build = {
      LUA="$(LUA)",
      LIBDIR="$(LIBDIR)",
      LUADIR="$(LUADIR)",
+     WITH_SHARED_LIBUV="$(WITH_SHARED_LIBUV)",
   },
 }
 


### PR DESCRIPTION
This makes it possible to use the system libuv when installing using the rockspec