### PR TITLE
Ensure consistent handling of _ex functions.

### DIFF
--- a/docs/docs.lua
+++ b/docs/docs.lua
@@ -2210,23 +2210,8 @@ local doc = {
           name = 'tcp_keepalive',
           method_form = 'tcp:keepalive(enable, [delay])',
           desc = [[
-            Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
+            Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, `intvl` is the time in seconds between individual keep-alive probes, and `cnt` is the number of probes to send before assuming the connection is dead.
             ignored when enable is `false`.
-          ]],
-          params = {
-            { name = 'tcp', type = 'uv_tcp_t' },
-            { name = 'enable', type = 'boolean' },
-            { name = 'delay', type = opt_int },
-          },
-          returns = success_ret,
-        },
-        {
-          name = 'tcp_keepalive_ex',
-          method_form = 'tcp:keepalive_ex(enable, [delay], [intvl], [cnt])',
-          desc = [[
-            Enable / disable TCP keep-alive with all socket options: TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT. `delay` is the value for TCP_KEEPIDLE, `intvl` is the value for TCP_KEEPINTVL, `cnt` is the value for TCP_KEEPCNT, ignored when `enable` is `false`.
-
-            With TCP keep-alive enabled, idle is the time (in seconds) the connection needs to remain idle before TCP starts sending keep-alive probes. intvl is the time (in seconds) between individual keep-alive probes. TCP will drop the connection after sending cnt probes without getting any replies from the peer, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
           ]],
           params = {
             { name = 'tcp', type = 'uv_tcp_t' },
@@ -2847,28 +2832,6 @@ local doc = {
         {
           name = 'udp_open',
           method_form = 'udp:open(fd)',
-          desc = [[
-            Opens an existing file descriptor or Windows SOCKET as a UDP handle.
-
-            Unix only: The only requirement of the sock argument is that it follows the
-            datagram contract (works in unconnected mode, supports sendmsg()/recvmsg(),
-            etc). In other words, other datagram-type sockets like raw sockets or netlink
-            sockets can also be passed to this function.
-
-            The file descriptor is set to non-blocking mode.
-
-            Note: The passed file descriptor or SOCKET is not checked for its type, but
-            it's required that it represents a valid datagram socket.
-          ]],
-          params = {
-            { name = 'udp', type = 'uv_udp_t' },
-            { name = 'fd', type = 'integer' },
-          },
-          returns = success_ret,
-        },
-        {
-          name = 'udp_open_ex',
-          method_form = 'udp:open_ex(fd, [flags])',
           desc = [[
             Opens an existing file descriptor or Windows SOCKET as a UDP handle.
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1701,23 +1701,9 @@ Enable / disable Nagle's algorithm.
 
 **Returns:** `0` or `fail`
 
-### `uv.tcp_keepalive(tcp, enable, [delay])`
+### `uv.tcp_keepalive(tcp, enable, [delay], [intvl], [cnt])`
 
 > method form `tcp:keepalive(enable, [delay])`
-
-**Parameters:**
-- `tcp`: `uv_tcp_t userdata`
-- `enable`: `boolean`
-- `delay`: `integer` or `nil`
-
-Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
-ignored when enable is `false`.
-
-**Returns:** `0` or `fail`
-
-### `uv.tcp_keepalive_ex(tcp, enable, [delay], [intvl], [cnt])`
-
-> method form `tcp:keepalive_ex(enable, [delay], [intvl], [cnt])`
 
 **Parameters:**
 - `tcp`: `uv_tcp_t userdata`
@@ -1726,9 +1712,8 @@ ignored when enable is `false`.
 - `intvl`: `integer` or `nil`
 - `cnt`: `integer` or `nil`
 
-Enable / disable TCP keep-alive with all socket options: TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT. `delay` is the value for TCP_KEEPIDLE, `intvl` is the value for TCP_KEEPINTVL, `cnt` is the value for TCP_KEEPCNT, ignored when `enable` is `false`.
-
-With TCP keep-alive enabled, idle is the time (in seconds) the connection needs to remain idle before TCP starts sending keep-alive probes. intvl is the time (in seconds) between individual keep-alive probes. TCP will drop the connection after sending cnt probes without getting any replies from the peer, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
+Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, `intvl` is the time in seconds between individual keep-alive probes, and `cnt` is the number of probes to send before assuming the connection is dead.
+ignored when enable is `false`.
 
 **Returns:** `0` or `fail`
 
@@ -2299,31 +2284,9 @@ Returns the handle's send queue count.
 
 **Returns:** `integer`
 
-### `uv.udp_open(udp, fd)`
+### `uv.udp_open(udp, fd, [flags])`
 
 > method form `udp:open(fd)`
-
-**Parameters:**
-- `udp`: `uv_udp_t userdata`
-- `fd`: `integer`
-
-Opens an existing file descriptor or Windows SOCKET as a UDP handle.
-
-Unix only: The only requirement of the sock argument is that it follows the
-datagram contract (works in unconnected mode, supports sendmsg()/recvmsg(),
-etc). In other words, other datagram-type sockets like raw sockets or netlink
-sockets can also be passed to this function.
-
-The file descriptor is set to non-blocking mode.
-
-Note: The passed file descriptor or SOCKET is not checked for its type, but
-it's required that it represents a valid datagram socket.
-
-**Returns:** `0` or `fail`
-
-### `uv.udp_open_ex(udp, fd, [flags])`
-
-> method form `udp:open_ex(fd, [flags])`
 
 **Parameters:**
 - `udp`: `uv_udp_t userdata`

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -1882,28 +1882,8 @@ function uv.tcp_nodelay(tcp, enable) end
 --- @return uv.error_name? err_name
 function uv_tcp_t:nodelay(enable) end
 
---- Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
+--- Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, `intvl` is the time in seconds between individual keep-alive probes, and `cnt` is the number of probes to send before assuming the connection is dead.
 --- ignored when enable is `false`.
---- @param tcp uv.uv_tcp_t
---- @param enable boolean
---- @param delay integer?
---- @return 0? success
---- @return string? err
---- @return uv.error_name? err_name
-function uv.tcp_keepalive(tcp, enable, delay) end
-
---- Enable / disable TCP keep-alive. `delay` is the initial delay in seconds,
---- ignored when enable is `false`.
---- @param enable boolean
---- @param delay integer?
---- @return 0? success
---- @return string? err
---- @return uv.error_name? err_name
-function uv_tcp_t:keepalive(enable, delay) end
-
---- Enable / disable TCP keep-alive with all socket options: TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT. `delay` is the value for TCP_KEEPIDLE, `intvl` is the value for TCP_KEEPINTVL, `cnt` is the value for TCP_KEEPCNT, ignored when `enable` is `false`.
----
---- With TCP keep-alive enabled, idle is the time (in seconds) the connection needs to remain idle before TCP starts sending keep-alive probes. intvl is the time (in seconds) between individual keep-alive probes. TCP will drop the connection after sending cnt probes without getting any replies from the peer, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
 --- @param tcp uv.uv_tcp_t
 --- @param enable boolean
 --- @param delay integer?
@@ -1912,11 +1892,10 @@ function uv_tcp_t:keepalive(enable, delay) end
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name
-function uv.tcp_keepalive_ex(tcp, enable, delay, intvl, cnt) end
+function uv.tcp_keepalive(tcp, enable, delay, intvl, cnt) end
 
---- Enable / disable TCP keep-alive with all socket options: TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT. `delay` is the value for TCP_KEEPIDLE, `intvl` is the value for TCP_KEEPINTVL, `cnt` is the value for TCP_KEEPCNT, ignored when `enable` is `false`.
----
---- With TCP keep-alive enabled, idle is the time (in seconds) the connection needs to remain idle before TCP starts sending keep-alive probes. intvl is the time (in seconds) between individual keep-alive probes. TCP will drop the connection after sending cnt probes without getting any replies from the peer, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
+--- Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, `intvl` is the time in seconds between individual keep-alive probes, and `cnt` is the number of probes to send before assuming the connection is dead.
+--- ignored when enable is `false`.
 --- @param enable boolean
 --- @param delay integer?
 --- @param intvl integer?
@@ -1924,7 +1903,7 @@ function uv.tcp_keepalive_ex(tcp, enable, delay, intvl, cnt) end
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name
-function uv_tcp_t:keepalive_ex(enable, delay, intvl, cnt) end
+function uv_tcp_t:keepalive(enable, delay, intvl, cnt) end
 
 --- Enable / disable simultaneous asynchronous accept requests that are queued by
 --- the operating system when listening for new TCP connections.
@@ -2599,46 +2578,11 @@ function uv_udp_t:get_send_queue_count() end
 --- it's required that it represents a valid datagram socket.
 --- @param udp uv.uv_udp_t
 --- @param fd integer
---- @return 0? success
---- @return string? err
---- @return uv.error_name? err_name
-function uv.udp_open(udp, fd) end
-
---- Opens an existing file descriptor or Windows SOCKET as a UDP handle.
----
---- Unix only: The only requirement of the sock argument is that it follows the
---- datagram contract (works in unconnected mode, supports sendmsg()/recvmsg(),
---- etc). In other words, other datagram-type sockets like raw sockets or netlink
---- sockets can also be passed to this function.
----
---- The file descriptor is set to non-blocking mode.
----
---- Note: The passed file descriptor or SOCKET is not checked for its type, but
---- it's required that it represents a valid datagram socket.
---- @param fd integer
---- @return 0? success
---- @return string? err
---- @return uv.error_name? err_name
-function uv_udp_t:open(fd) end
-
---- Opens an existing file descriptor or Windows SOCKET as a UDP handle.
----
---- Unix only: The only requirement of the sock argument is that it follows the
---- datagram contract (works in unconnected mode, supports sendmsg()/recvmsg(),
---- etc). In other words, other datagram-type sockets like raw sockets or netlink
---- sockets can also be passed to this function.
----
---- The file descriptor is set to non-blocking mode.
----
---- Note: The passed file descriptor or SOCKET is not checked for its type, but
---- it's required that it represents a valid datagram socket.
---- @param udp uv.uv_udp_t
---- @param fd integer
 --- @param flags integer|{ reuseaddr: boolean?, reuseport: boolean? }?
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name
-function uv.udp_open_ex(udp, fd, flags) end
+function uv.udp_open(udp, fd, flags) end
 
 --- Opens an existing file descriptor or Windows SOCKET as a UDP handle.
 ---
@@ -2656,7 +2600,7 @@ function uv.udp_open_ex(udp, fd, flags) end
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name
-function uv_udp_t:open_ex(fd, flags) end
+function uv_udp_t:open(fd, flags) end
 
 --- Bind the UDP handle to an IP address and port. Any `flags` are set with a table
 --- with fields `reuseaddr` or `ipv6only` equal to `true` or `false`.

--- a/src/luv.c
+++ b/src/luv.c
@@ -164,9 +164,6 @@ static const luaL_Reg luv_functions[] = {
   {"tcp_open", luv_tcp_open},
   {"tcp_nodelay", luv_tcp_nodelay},
   {"tcp_keepalive", luv_tcp_keepalive},
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-  {"tcp_keepalive_ex", luv_tcp_keepalive_ex},
-#endif
   {"tcp_simultaneous_accepts", luv_tcp_simultaneous_accepts},
   {"tcp_bind", luv_tcp_bind},
   {"tcp_getpeername", luv_tcp_getpeername},
@@ -218,9 +215,6 @@ static const luaL_Reg luv_functions[] = {
   {"udp_get_send_queue_size", luv_udp_get_send_queue_size},
   {"udp_get_send_queue_count", luv_udp_get_send_queue_count},
   {"udp_open", luv_udp_open},
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-  {"udp_open_ex", luv_udp_open_ex},
-#endif
   {"udp_bind", luv_udp_bind},
   {"udp_getsockname", luv_udp_getsockname},
   {"udp_set_membership", luv_udp_set_membership},
@@ -562,9 +556,6 @@ static const luaL_Reg luv_tcp_methods[] = {
   {"open", luv_tcp_open},
   {"nodelay", luv_tcp_nodelay},
   {"keepalive", luv_tcp_keepalive},
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-  {"keepalive_ex", luv_tcp_keepalive_ex},
-#endif
   {"simultaneous_accepts", luv_tcp_simultaneous_accepts},
   {"bind", luv_tcp_bind},
   {"getpeername", luv_tcp_getpeername},
@@ -599,9 +590,6 @@ static const luaL_Reg luv_udp_methods[] = {
   {"get_send_queue_size", luv_udp_get_send_queue_size},
   {"get_send_queue_count", luv_udp_get_send_queue_count},
   {"open", luv_udp_open},
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-  {"open_ex", luv_udp_open_ex},
-#endif
   {"bind", luv_udp_bind},
   {"getsockname", luv_udp_getsockname},
   {"set_membership", luv_udp_set_membership},

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -82,31 +82,23 @@ static int luv_tcp_keepalive(lua_State* L) {
   unsigned int delay = 0;
   luaL_checktype(L, 2, LUA_TBOOLEAN);
   enable = lua_toboolean(L, 2);
-  if (enable) {
-    delay = luaL_checkinteger(L, 3);
-  }
-  ret = uv_tcp_keepalive(handle, enable, delay);
-  return luv_result(L, ret);
-}
-
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-static int luv_tcp_keepalive_ex(lua_State* L) {
-  uv_tcp_t* handle = luv_check_tcp(L, 1);
-  int ret, enable;
-  unsigned int delay = 0;
+  #if LUV_UV_VERSION_GEQ(1, 52, 0)
   unsigned int intvl = 1; // defaults chosen in uv_tcp_keepalive on libuv 1.52.0
   unsigned int cnt = 10; // defaults chosen in uv_tcp_keepalive on libuv 1.52.0
-  luaL_checktype(L, 2, LUA_TBOOLEAN);
-  enable = lua_toboolean(L, 2);
   if (enable) {
     delay = luaL_checkinteger(L, 3);
     intvl = luaL_optinteger(L, 4, intvl);
     cnt = luaL_optinteger(L, 5, cnt);
   }
   ret = uv_tcp_keepalive_ex(handle, enable, delay, intvl, cnt);
+  #else
+  if (enable) {
+    delay = luaL_checkinteger(L, 3);
+  }
+  ret = uv_tcp_keepalive(handle, enable, delay);
+  #endif
   return luv_result(L, ret);
 }
-#endif
 
 static int luv_tcp_simultaneous_accepts(lua_State* L) {
   uv_tcp_t* handle = luv_check_tcp(L, 1);

--- a/src/udp.c
+++ b/src/udp.c
@@ -126,15 +126,9 @@ static int luv_udp_get_send_queue_count(lua_State* L) {
 static int luv_udp_open(lua_State* L) {
   uv_udp_t* handle = luv_check_udp(L, 1);
   uv_os_sock_t sock = luaL_checkinteger(L, 2);
-  int ret = uv_udp_open(handle, sock);
-  return luv_result(L, ret);
-}
-
-#if LUV_UV_VERSION_GEQ(1, 52, 0)
-static int luv_udp_open_ex(lua_State* L) {
-  uv_udp_t* handle = luv_check_udp(L, 1);
-  uv_os_sock_t sock = luaL_checkinteger(L, 2);
+  #if LUV_UV_VERSION_GEQ(1, 52, 0)
   unsigned int flags = 0;
+
   if (!lua_isnoneornil(L, 3)) {
     if (lua_isinteger(L, 3)) {
       flags = (unsigned int)lua_tointeger(L, 3);
@@ -151,9 +145,11 @@ static int luv_udp_open_ex(lua_State* L) {
   }
 
   int ret = uv_udp_open_ex(handle, sock, flags);
+  #else
+  int ret = uv_udp_open(handle, sock);
+  #endif
   return luv_result(L, ret);
 }
-#endif
 
 static int luv_udp_bind(lua_State* L) {
   uv_udp_t* handle = luv_check_udp(L, 1);


### PR DESCRIPTION
The existing behavior around `_ex` functions has been to coalesce them with their other forms and silently ignore flags that are not supported on the target libuv version. I got this wrong in the last PR, so here's to making that consistent.

+ `udp_open_ex` has been merged into `udp_open` and handles the given flags when possible.
+ `tcp_keepalive_ex` has been merged into `tcp_keepalive` and handles the given flags when possible.
