### PR TITLE
udp: Add `bind` flags that got lost along the way

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2320,11 +2320,40 @@ it's required that it represents a valid datagram socket.
 - `flags`: `table` or `nil`
   - `ipv6only`: `boolean` or `nil`
   - `reuseaddr`: `boolean` or `nil`
+  - `linux_recverr`: `boolean` or `nil`
+  - `reuseport`: `boolean` or `nil`
 
 Bind the UDP handle to an IP address and port. Any `flags` are set with a table
-with fields `reuseaddr` or `ipv6only` equal to `true` or `false`.
+with fields `reuseaddr`, `ipv6only`, `linux_recverr`, `reuseport` equal to `true` or `false`.
+
+- `reuseaddr`: Indicates if SO_REUSEADDR will be set when binding the handle.
+  This sets the SO_REUSEPORT socket flag on the BSDs (except for
+  DragonFlyBSD), OS X, and other platforms where SO_REUSEPORTs don't
+  have the capability of load balancing, as the opposite of what
+  `reuseport` would do. On other Unix platforms, it sets the
+  SO_REUSEADDR flag. What that means is that multiple threads or
+  processes can bind to the same address without error (provided
+  they all set the flag) but only the last one to bind will receive
+  any traffic, in effect "stealing" the port from the previous listener.
+- `ipv6only`: Disables dual stack mode.
+- `linux_recverr`: Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+  This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+  Linux. This stops the Linux kernel from suppressing some ICMP error messages
+  and enables full ICMP error reporting for faster failover.
+  This flag is no-op on platforms other than Linux.
+- `reuseport`: Indicates if SO_REUSEPORT will be set when binding the handle.
+  This sets the SO_REUSEPORT socket option on supported platforms.
+  Unlike `reuseaddr`, this flag will make multiple threads or
+  processes that are binding to the same address and port "share"
+  the port, which means incoming datagrams are distributed across
+  the receiving sockets among threads or processes.
+  This flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+  FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+ for now.
 
 **Returns:** `0` or `fail`
+
+**Note**: The flag `linux_recverr` is only supported with Libuv >= 1.42.0.
+The flag `reuseport` is only supported with Libuv >= 1.49.0.
 
 ### `uv.udp_getsockname(udp)`
 

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -2602,22 +2602,82 @@ function uv.udp_open(udp, fd, flags) end
 --- @return uv.error_name? err_name
 function uv_udp_t:open(fd, flags) end
 
+--- @class uv.udp_bind.flags
+--- @field ipv6only boolean?
+--- @field reuseaddr boolean?
+--- @field linux_recverr boolean?
+--- @field reuseport boolean?
+
 --- Bind the UDP handle to an IP address and port. Any `flags` are set with a table
---- with fields `reuseaddr` or `ipv6only` equal to `true` or `false`.
+--- with fields `reuseaddr`, `ipv6only`, `linux_recverr`, `reuseport` equal to `true` or `false`.
+---
+--- - `reuseaddr`: Indicates if SO_REUSEADDR will be set when binding the handle.
+---   This sets the SO_REUSEPORT socket flag on the BSDs (except for
+---   DragonFlyBSD), OS X, and other platforms where SO_REUSEPORTs don't
+---   have the capability of load balancing, as the opposite of what
+---   `reuseport` would do. On other Unix platforms, it sets the
+---   SO_REUSEADDR flag. What that means is that multiple threads or
+---   processes can bind to the same address without error (provided
+---   they all set the flag) but only the last one to bind will receive
+---   any traffic, in effect "stealing" the port from the previous listener.
+--- - `ipv6only`: Disables dual stack mode.
+--- - `linux_recverr`: Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+---   This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+---   Linux. This stops the Linux kernel from suppressing some ICMP error messages
+---   and enables full ICMP error reporting for faster failover.
+---   This flag is no-op on platforms other than Linux.
+--- - `reuseport`: Indicates if SO_REUSEPORT will be set when binding the handle.
+---   This sets the SO_REUSEPORT socket option on supported platforms.
+---   Unlike `reuseaddr`, this flag will make multiple threads or
+---   processes that are binding to the same address and port "share"
+---   the port, which means incoming datagrams are distributed across
+---   the receiving sockets among threads or processes.
+---   This flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+---   FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+ for now.
+--- **Note**:
+--- The flag `linux_recverr` is only supported with Libuv >= 1.42.0.
+--- The flag `reuseport` is only supported with Libuv >= 1.49.0.
 --- @param udp uv.uv_udp_t
 --- @param host string
 --- @param port number
---- @param flags { ipv6only: boolean?, reuseaddr: boolean? }?
+--- @param flags uv.udp_bind.flags?
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name
 function uv.udp_bind(udp, host, port, flags) end
 
 --- Bind the UDP handle to an IP address and port. Any `flags` are set with a table
---- with fields `reuseaddr` or `ipv6only` equal to `true` or `false`.
+--- with fields `reuseaddr`, `ipv6only`, `linux_recverr`, `reuseport` equal to `true` or `false`.
+---
+--- - `reuseaddr`: Indicates if SO_REUSEADDR will be set when binding the handle.
+---   This sets the SO_REUSEPORT socket flag on the BSDs (except for
+---   DragonFlyBSD), OS X, and other platforms where SO_REUSEPORTs don't
+---   have the capability of load balancing, as the opposite of what
+---   `reuseport` would do. On other Unix platforms, it sets the
+---   SO_REUSEADDR flag. What that means is that multiple threads or
+---   processes can bind to the same address without error (provided
+---   they all set the flag) but only the last one to bind will receive
+---   any traffic, in effect "stealing" the port from the previous listener.
+--- - `ipv6only`: Disables dual stack mode.
+--- - `linux_recverr`: Indicates if IP_RECVERR/IPV6_RECVERR will be set when binding the handle.
+---   This sets IP_RECVERR for IPv4 and IPV6_RECVERR for IPv6 UDP sockets on
+---   Linux. This stops the Linux kernel from suppressing some ICMP error messages
+---   and enables full ICMP error reporting for faster failover.
+---   This flag is no-op on platforms other than Linux.
+--- - `reuseport`: Indicates if SO_REUSEPORT will be set when binding the handle.
+---   This sets the SO_REUSEPORT socket option on supported platforms.
+---   Unlike `reuseaddr`, this flag will make multiple threads or
+---   processes that are binding to the same address and port "share"
+---   the port, which means incoming datagrams are distributed across
+---   the receiving sockets among threads or processes.
+---   This flag is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+---   FreeBSD 12.0+, Solaris 11.4, and AIX 7.2.5+ for now.
+--- **Note**:
+--- The flag `linux_recverr` is only supported with Libuv >= 1.42.0.
+--- The flag `reuseport` is only supported with Libuv >= 1.49.0.
 --- @param host string
 --- @param port number
---- @param flags { ipv6only: boolean?, reuseaddr: boolean? }?
+--- @param flags uv.udp_bind.flags?
 --- @return 0? success
 --- @return string? err
 --- @return uv.error_name? err_name

--- a/src/udp.c
+++ b/src/udp.c
@@ -175,6 +175,16 @@ static int luv_udp_bind(lua_State* L) {
     lua_getfield(L, 4, "ipv6only");
     if (lua_toboolean(L, -1)) flags |= UV_UDP_IPV6ONLY;
     lua_pop(L, 1);
+#if LUV_UV_VERSION_GEQ(1, 42, 0)
+    lua_getfield(L, 4, "linux_recverr");
+    if (lua_toboolean(L, -1)) flags |= UV_UDP_LINUX_RECVERR;
+    lua_pop(L, 1);
+#endif
+#if LUV_UV_VERSION_GEQ(1, 49, 0)
+    lua_getfield(L, 4, "reuseport");
+    if (lua_toboolean(L, -1)) flags |= UV_UDP_REUSEPORT;
+    lua_pop(L, 1);
+#endif
   }
   ret = uv_udp_bind(handle, (struct sockaddr*)&addr, flags);
   return luv_result(L, ret);


### PR DESCRIPTION
These flags were added in 1.42.0 and 1.49.0 but went unnoticed.