### PR TITLE
Use a unique string for the handle registry instead of a reference

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -123,8 +123,8 @@ static void luv_handle_free(uv_handle_t* handle) {
   if (data) {
     luv_ctx_t* ctx = data->ctx;
     lua_State* L = ctx->L;
-    // release handle in ht_ref
-    lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->ht_ref);
+    // release handle in handle registry
+    lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key);
     lua_pushnil(L);
     lua_rawsetp(L, -2, data);
     lua_pop(L, 1);

--- a/src/lhandle.c
+++ b/src/lhandle.c
@@ -54,8 +54,8 @@ static luv_handle_t* luv_setup_handle(lua_State* L, luv_ctx_t* ctx) {
   data->extra = NULL;
   data->extra_gc = NULL;
 
-  // record data in ht_ref
-  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->ht_ref);
+  // record data in handle registry
+  lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key);
   lua_pushboolean(L, 1);
   lua_rawsetp(L, -2, data);
   lua_pop(L, 1);

--- a/src/lhandle.h
+++ b/src/lhandle.h
@@ -52,4 +52,6 @@ typedef struct {
 
 static void luv_handle_free(uv_handle_t* handle);
 
+static const char* luv_handle_key = "LUV_HANDLES";
+
 #endif

--- a/src/loop.c
+++ b/src/loop.c
@@ -95,31 +95,35 @@ static int luv_update_time(lua_State* L) {
 }
 
 static void luv_walk_cb(uv_handle_t* handle, void* arg) {
-  luv_ctx_t* ctx = (luv_ctx_t*)arg;
-  lua_State* L = ctx->L;
+  lua_State* L = (lua_State*)arg;
   luv_handle_t* data = (luv_handle_t*)handle->data;
 
   // Skip foreign handles (shared event loop)
-  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->ht_ref);
-  lua_rawgetp(L, -1, data);
+  lua_rawgetp(L, 2, data);
   if (lua_isnil(L, -1)) {
-    lua_pop(L, 2);
+    lua_pop(L, 1);
     return;
   }
+  lua_pop(L, 1);
 
-  // Sanity check
-  // Most invalid values are large and refs are small, 0x1000000 is arbitrary.
-  assert(data && data->ref < 0x1000000);
+  // We know that data is a valid luv_handle_t* because the above check succeeded.
 
   lua_pushvalue(L, 1);           // Copy the function
   luv_find_handle(L, data);      // Get the userdata
+  uv_handle_t **udata = (uv_handle_t**)lua_touserdata(L, -1);
+  if (udata == NULL || *udata != handle) {
+    lua_pop(L, 2); // Pop the function and the userdata
+    return;
+  }
+
   data->ctx->cb_pcall(L, 1, 0, 0);  // Call the function
 }
 
 static int luv_walk(lua_State* L) {
-  luv_ctx_t* ctx = luv_context(L);
   luaL_checktype(L, 1, LUA_TFUNCTION);
-  uv_walk(luv_loop(L), luv_walk_cb, ctx);
+  lua_settop(L, 1);
+  lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key);
+  uv_walk(luv_loop(L), luv_walk_cb, L);
   return 0;
 }
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -95,10 +95,18 @@ static int luv_update_time(lua_State* L) {
 }
 
 static void luv_walk_cb(uv_handle_t* handle, void* arg) {
+  // This function expects to be passed a lua_State* with a callback function
+  // at index 1 and the handle registry table at index 2. Libuv always calls
+  // this function synchronously in uv_walk, so we can rely on the Lua state
+  // from the caller of luv_walk instead of dispatching to the loop's main
+  // thread both to avoid the xmove and to allow tracebacks to pass through
+  // luv_walk.
+
   lua_State* L = (lua_State*)arg;
   luv_handle_t* data = (luv_handle_t*)handle->data;
 
-  // Skip foreign handles (shared event loop)
+  // check if registry[luv_handle_key][data] is not nil, which will only be true
+  // if the data refers to a valid luv_handle_t* that is still in use.
   lua_rawgetp(L, 2, data);
   if (lua_isnil(L, -1)) {
     lua_pop(L, 1);
@@ -112,6 +120,10 @@ static void luv_walk_cb(uv_handle_t* handle, void* arg) {
   luv_find_handle(L, data);      // Get the userdata
   uv_handle_t **udata = (uv_handle_t**)lua_touserdata(L, -1);
   if (udata == NULL || *udata != handle) {
+    // This will only happen if someone forged a uv_handle_t* that points to a
+    // uv_handle_t* created by luv. This is very unlikely, but if data does
+    // happen to be unintentionally pointer-like we should avoid treating it
+    // as valid.
     lua_pop(L, 2); // Pop the function and the userdata
     return;
   }
@@ -120,9 +132,9 @@ static void luv_walk_cb(uv_handle_t* handle, void* arg) {
 }
 
 static int luv_walk(lua_State* L) {
-  luaL_checktype(L, 1, LUA_TFUNCTION);
-  lua_settop(L, 1);
-  lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key);
+  luaL_checktype(L, 1, LUA_TFUNCTION);                // Ensure index 1 is a function
+  lua_settop(L, 1);                                   // Remove any extra arguments
+  lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key); // Place the handle registry table at index 2
   uv_walk(luv_loop(L), luv_walk_cb, L);
   return 0;
 }

--- a/src/luv.c
+++ b/src/luv.c
@@ -797,7 +797,7 @@ LUALIB_API luv_ctx_t* luv_context(lua_State* L) {
     lua_rawset(L, LUA_REGISTRYINDEX);
     // create table to contain internal handle
     lua_newtable(L);
-    ctx->ht_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    lua_setfield(L, LUA_REGISTRYINDEX, luv_handle_key);
   } else {
     ctx = (luv_ctx_t*)lua_touserdata(L, -1);
   }

--- a/src/luv.h
+++ b/src/luv.h
@@ -104,8 +104,6 @@ typedef struct {
   luv_CFcpcall thrd_cpcall; /* luv thread c function in protected mode*/
 
   int          mode;        /* the mode used to run the loop (-1 if not running) */
-  int          ht_ref;      /* bookkeeping: maintain table of luv_handle_t pointers,
-                               to distinguish between internal and external handles */
 
   void* extra;              /* extra data */
 } luv_ctx_t;

--- a/src/test.c
+++ b/src/test.c
@@ -104,7 +104,7 @@ static void walk_cb(uv_handle_t* handle, void* arg) {
   luv_handle_t* data = (luv_handle_t*)handle->data;
 
   // Skip foreign handles (shared event loop)
-  lua_rawgeti(L, LUA_REGISTRYINDEX, ctx->ht_ref);
+  lua_getfield(L, LUA_REGISTRYINDEX, luv_handle_key);
   lua_rawgetp(L, -1, data);
 
 #if LUV_UV_VERSION_GEQ(1, 19, 0)


### PR DESCRIPTION
There can only be one luv_context per lua registry, so there can also only be one handle registry per lua registry. Therefore, we don't need to store this as a reference; we can use a unique registry key.

This allows simplifying luv_walk to pass only the lua_State again, which is necessary to fix #808. The existing code uses the loop's Lua state, but luv_walk_cb is always called synchronously and expects the arguments of the function to be accessible on the stack.