### PR TITLE
Potential for buffer overflow after realloc failure

### DIFF
--- a/src/work.c
+++ b/src/work.c
@@ -137,14 +137,15 @@ static lua_State* luv_work_acquire_vm(luv_work_vms_t* vms)
 
     uv_mutex_lock(&vms->vm_mutex);
     if (vms->idx_vms >= vms->nvms) {
-      vms->nvms *= 2;
+      unsigned int new_nvms = vms->nvms * 2;
 
-      lua_State **new_vms= realloc(vms->vms, sizeof(lua_State*) * vms->nvms);
+      lua_State **new_vms= realloc(vms->vms, sizeof(lua_State*) * new_nvms);
       if (!new_vms) {
         uv_mutex_unlock(&vms->vm_mutex);
         return L; // we failed to realloc, so we will leak this vm, but we have no choice at this point
       }
       vms->vms = new_vms;
+      vms->nvms = new_nvms;
 
       for (unsigned int i = vms->idx_vms; i < vms->nvms; i++) {
         vms->vms[i] = NULL;


### PR DESCRIPTION
I reworked this code in my last change but this made it through, the value of nvms can only change after the realloc call succeeds, otherwise the the old vms array will still be active, but nvms will be double the valid size, which can cause a buffer overflow if the code tries to access the past the end of the vms array.