### PR TITLE
CMake: Fix version detection for Lua 5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,36 +165,28 @@ else (LUA)
 endif (LUA)
 
 if (EXISTS "${LUA_INCLUDE_DIR}/lua.h")
-    # At least 5.[012] have different ways to express the version
-    # so all of them need to be tested. Lua 5.2 defines LUA_VERSION
-    # and LUA_RELEASE as joined by the C preprocessor, so avoid those.
+  # At least 5.[012] have different ways to express the version
+  # so all of them need to be tested. Lua 5.2 defines LUA_VERSION
+  # and LUA_RELEASE as joined by the C preprocessor, so avoid those.
+  file(STRINGS "${LUA_INCLUDE_DIR}/lua.h" lua_version_strings
+       REGEX "^#define[ \t]+LUA_(RELEASE[ \t]+\"Lua [0-9]|VERSION([ \t]+\"Lua [0-9]|_[MR])).*")
 
-    # lua 5.2 and above
-    file(STRINGS "${LUA_INCLUDE_DIR}/lua.h" LUA_VERSION_MAJOR
-         REGEX "^#define[ \t]+LUA_VERSION_MAJOR[ \t]+\"Lua [0-9]+")
-    file(STRINGS "${LUA_INCLUDE_DIR}/lua.h" LUA_VERSION_MINOR
-         REGEX "^#define[ \t]+LUA_VERSION_MINOR[ \t]+\"Lua [0-9]+")
+  string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" LUA_VERSION_MAJOR ";${lua_version_strings};")
+  if (LUA_VERSION_MAJOR MATCHES "^[0-9]+$")
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" LUA_VERSION_MINOR ";${lua_version_strings};")
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" LUA_VERSION_PATCH ";${lua_version_strings};")
+    set(LUA_VERSION_STRING "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
+  else ()
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+    if (NOT LUA_VERSION_STRING MATCHES "^[0-9.]+$")
+      string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
+    endif ()
+    string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" LUA_VERSION_MAJOR "${LUA_VERSION_STRING}")
+    string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" LUA_VERSION_MINOR "${LUA_VERSION_STRING}")
+    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" LUA_VERSION_PATCH "${LUA_VERSION_STRING}")
+  endif ()
 
-    if(NOT LUA_VERSION_MAJOR AND NOT LUA_VERSION_MINOR)
-      file(STRINGS "${LUA_INCLUDE_DIR}/lua.h" lua_version_strings
-           REGEX "^#define[ \t]+LUA_VERSION([ \t]+\"Lua [0-9]|_[MR]).*")
-      string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MAJOR ";${lua_version_strings};")
-      if (LUA_VERSION_MAJOR MATCHES "^[0-9]+$")
-          string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_MINOR ";${lua_version_strings};")
-          string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE[ \t]+\"([0-9])\"[ \t]*;.*" "\\1" LUA_VERSION_PATCH ";${lua_version_strings};")
-          set(LUA_VERSION_STRING "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
-      else ()
-          string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
-          if (NOT LUA_VERSION_STRING MATCHES "^[0-9.]+$")
-              string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" LUA_VERSION_STRING ";${lua_version_strings};")
-          endif ()
-          string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" LUA_VERSION_MAJOR "${LUA_VERSION_STRING}")
-          string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" LUA_VERSION_MINOR "${LUA_VERSION_STRING}")
-          string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" LUA_VERSION_PATCH "${LUA_VERSION_STRING}")
-      endif ()
-
-      unset(lua_version_strings)
-    endif()
+  unset(lua_version_strings)
 endif()
 
 if (BUILD_MODULE)


### PR DESCRIPTION
This logic needed to be synced with CMake's FindLua.cmake. Ideally the duplication of this logic between CMakeLists.txt/FindLua.cmake would be deduplicated but I haven't done that here.

Note: The diff looks messier than it really is due to some extra logic that was added in CMakeLists.txt that I've removed (it looks like it was basically a fast-path for Lua 5.2+, but it won't work for 5.5+ so I didn't think it was worth trying to keep). The real diff is basically the same as https://github.com/luvit/luv/commit/297bd3341257a534cb3f7759ba20aac8916ce93d

Fixes https://github.com/luvit/luv/issues/787#issuecomment-4041758224