### PR TITLE
Fix use-after-free when forcibly reloading the luv module

### DIFF
--- a/src/luv.c
+++ b/src/luv.c
@@ -859,6 +859,12 @@ static int loop_gc(lua_State *L) {
   while (uv_loop_close(loop)) {
     uv_run(loop, UV_RUN_DEFAULT);
   }
+  // Set the loop to NULL to allow for multiple calls
+  // of luaopen_luv, e.g. requiring 'luv', then setting
+  // package.loaded['luv'] to nil, and then requiring 'luv' again.
+  // The context lives as long as the Lua state, so it's
+  // possible it could be around for multiple loops.
+  ctx->loop = NULL;
   return 0;
 }
 


### PR DESCRIPTION
Closes https://github.com/luvit/luv/issues/819

I was still not able to reproduce the bug with garbage collection alone, but this also fixes a modified version of the reproduction with an explicit `loop_close`:

```lua
local uv = require "luv"

local timer = uv.new_timer()
timer:start(100, 0, function() timer:close() end)
uv.run()

package.loaded["luv"] = nil
-- forcibly close the loop
uv.loop_close()

-- Step 3: Re-require and use → SEGFAULT (previously)
local uv2 = require "luv"
local timer2 = uv2.new_timer()  -- no segfault here :)
```