### PR TITLE
breaking change: Remove ad-hoc setuid/setgid bindings

### DIFF
--- a/docs/docs.lua
+++ b/docs/docs.lua
@@ -4442,7 +4442,12 @@ local doc = {
           desc = 'Returns the user ID of the process.',
           returns = 'integer',
           notes = {
-            'This is not a libuv function and is not supported on Windows.',
+            'This is not a libuv function and does not exist when targeting Windows.',
+          },
+          warnings = {
+            [[
+              Deprecated. Use `uv.os_get_passwd()` instead.
+            ]],
           },
         },
         {
@@ -4450,27 +4455,12 @@ local doc = {
           desc = 'Returns the group ID of the process.',
           returns = 'integer',
           notes = {
-            'This is not a libuv function and is not supported on Windows.',
+            'This is not a libuv function and does not exist when targeting Windows.',
           },
-        },
-        {
-          name = 'setuid',
-          desc = 'Sets the user ID of the process with the integer `id`.',
-          params = {
-            { name = 'id', type = 'integer' },
-          },
-          notes = {
-            'This is not a libuv function and is not supported on Windows.',
-          },
-        },
-        {
-          name = 'setgid',
-          desc = 'Sets the group ID of the process with the integer `id`.',
-          params = {
-            { name = 'id', type = 'integer' },
-          },
-          notes = {
-            'This is not a libuv function and is not supported on Windows.',
+          warnings = {
+            [[
+              Deprecated. Use `uv.os_get_passwd()` instead.
+            ]],
           },
         },
         {

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -4125,7 +4125,9 @@ Returns the user ID of the process.
 
 **Returns:** `integer`
 
-**Note**: This is not a libuv function and is not supported on Windows.
+**Note**: This is not a libuv function and does not exist when targeting Windows.
+
+**Warning**: Deprecated. Use `uv.os_get_passwd()` instead.
 
 ### `uv.getgid()`
 
@@ -4133,29 +4135,9 @@ Returns the group ID of the process.
 
 **Returns:** `integer`
 
-**Note**: This is not a libuv function and is not supported on Windows.
+**Note**: This is not a libuv function and does not exist when targeting Windows.
 
-### `uv.setuid(id)`
-
-**Parameters:**
-- `id`: `integer`
-
-Sets the user ID of the process with the integer `id`.
-
-**Returns:** Nothing.
-
-**Note**: This is not a libuv function and is not supported on Windows.
-
-### `uv.setgid(id)`
-
-**Parameters:**
-- `id`: `integer`
-
-Sets the group ID of the process with the integer `id`.
-
-**Returns:** Nothing.
-
-**Note**: This is not a libuv function and is not supported on Windows.
+**Warning**: Deprecated. Use `uv.os_get_passwd()` instead.
 
 ### `uv.hrtime()`
 

--- a/docs/meta.lua
+++ b/docs/meta.lua
@@ -4255,27 +4255,19 @@ function uv.getpid() end
 
 --- Returns the user ID of the process.
 --- **Note**:
---- This is not a libuv function and is not supported on Windows.
+--- This is not a libuv function and does not exist when targeting Windows.
+--- **Warning**:
+--- Deprecated. Use `uv.os_get_passwd()` instead.
 --- @return integer
 function uv.getuid() end
 
 --- Returns the group ID of the process.
 --- **Note**:
---- This is not a libuv function and is not supported on Windows.
+--- This is not a libuv function and does not exist when targeting Windows.
+--- **Warning**:
+--- Deprecated. Use `uv.os_get_passwd()` instead.
 --- @return integer
 function uv.getgid() end
-
---- Sets the user ID of the process with the integer `id`.
---- **Note**:
---- This is not a libuv function and is not supported on Windows.
---- @param id integer
-function uv.setuid(id) end
-
---- Sets the group ID of the process with the integer `id`.
---- **Note**:
---- This is not a libuv function and is not supported on Windows.
---- @param id integer
-function uv.setgid(id) end
 
 --- Returns a current high-resolution time in nanoseconds as a number. This is
 --- relative to an arbitrary time in the past. It is not related to the time of day

--- a/src/luv.c
+++ b/src/luv.c
@@ -329,9 +329,7 @@ static const luaL_Reg luv_functions[] = {
   {"getpid", luv_getpid},
 #ifndef _WIN32
   {"getuid", luv_getuid},
-  {"setuid", luv_setuid},
   {"getgid", luv_getgid},
-  {"setgid", luv_setgid},
 #endif
   {"getrusage", luv_getrusage},
 #if LUV_UV_VERSION_GEQ(1, 50, 0)

--- a/src/misc.c
+++ b/src/misc.c
@@ -473,24 +473,6 @@ static int luv_getgid(lua_State* L){
   return 1;
 }
 
-static int luv_setuid(lua_State* L){
-  int uid = luaL_checkinteger(L, 1);
-  int r = setuid(uid);
-  if (-1 == r) {
-    luaL_error(L, "Error setting UID");
-  }
-  return 0;
-}
-
-static int luv_setgid(lua_State* L){
-  int gid = luaL_checkinteger(L, 1);
-  int r = setgid(gid);
-  if (-1 == r) {
-    luaL_error(L, "Error setting GID");
-  }
-  return 0;
-}
-
 #if LUV_UV_VERSION_GEQ(1, 8, 0)
 static int luv_print_all_handles(lua_State* L){
   luv_ctx_t* ctx = luv_context(L);


### PR DESCRIPTION
These functions aren't coming from libuv, they aren't portable (to the point of the function bindings being wrapped in a `#ifndef _WIN32`), and there's proper support for setgid/setuid in the libuv process spawning API.

These functions are also [seemingly unused except by a single personal project for which the bindings were added in the first place](https://github.com/luvit/luv/issues/341#issuecomment-4093855494). The ad-hoc getuid/getgid functions do see some use in neovim plugins, so they remain but it's now recommended to use the proper `os_get_passwd` function from libuv instead.

There's also some potential security issues around setuid/setgid that we aren't dealing with correctly and there's no good reason to take on that responsibility (closes https://github.com/luvit/luv/issues/341).

---

Alternative to https://github.com/luvit/luv/pull/817